### PR TITLE
chore: only deploy docs on release

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,11 +1,10 @@
 name: Build and Deploy Documentation
+
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
+  release:
+    types: [released]
   workflow_dispatch:
+
 permissions:
   contents: write
   pages: write


### PR DESCRIPTION
fixes #284 

this should help a bit until we setup nightly releases or versioned docs.