### PR TITLE
Fix link to VSCode Marketplace

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ npm add --save-dev --save-exact @postgrestools/postgrestools
 
 ### VSCode
 
-The language server is available on the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=Supabase.postgrestools-vscode). Its published from [this repo](https://github.com/supabase-community/postgrestools-vscode).
+The language server is available on the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=Supabase.postgrestools). Its published from [this repo](https://github.com/supabase-community/postgrestools-vscode).
 
 ### Neovim
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update fixing link to VSCode Marketplace

## What is the current behavior?

link 404s

## What is the new behavior?

Links to VSCode extension page

## Additional context

none
