### PR TITLE
fix: version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,16 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
 
+      - name: Set version name
+        run: echo "version=(git cliff --bumped-version)" >> $GITHUB_ENV
+
       - name: 🛠️ Run Build
         run: cargo build -p pgt_cli --release --target ${{ matrix.config.target }}
+        # Strip all debug symbols from the resulting binaries
+        RUSTFLAGS: "-C strip=symbols -C codegen-units=1"
+        # Inline the version in the CLI binary
+        PGT_VERSION: ${{ env.version }}
+
 
       # windows is a special snowflake too, it saves binaries as .exe
       - name: 👦 Name the Binary


### PR DESCRIPTION
fixes #279 

I *think* `—bumped-version` returns the same version as the `bump` we call later but without actually bumping. let me know if this is correct @juleswritescode.

docs: https://git-cliff.org/docs/usage/bump-version#get-version