### PR TITLE
fix: execute statement reliable

### DIFF
--- a/crates/pgt_lsp/src/handlers/code_actions.rs
+++ b/crates/pgt_lsp/src/handlers/code_actions.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use crate::{adapters::get_cursor_position, session::Session};
 use anyhow::{Result, anyhow};
 use tower_lsp::lsp_types::{
@@ -90,6 +92,8 @@ pub async fn execute_command(
                     statement_id: id,
                     path,
                 })?;
+
+            std::sync::atomic::fence(Ordering::SeqCst);
 
             /*
              * Updating all diagnostics: the changes caused by the statement execution

--- a/crates/pgt_lsp/src/handlers/code_actions.rs
+++ b/crates/pgt_lsp/src/handlers/code_actions.rs
@@ -93,8 +93,6 @@ pub async fn execute_command(
                     path,
                 })?;
 
-            std::sync::atomic::fence(Ordering::SeqCst);
-
             /*
              * Updating all diagnostics: the changes caused by the statement execution
              * might affect many files.

--- a/crates/pgt_lsp/src/handlers/code_actions.rs
+++ b/crates/pgt_lsp/src/handlers/code_actions.rs
@@ -98,8 +98,6 @@ pub async fn execute_command(
             /*
              * Updating all diagnostics: the changes caused by the statement execution
              * might affect many files.
-             *
-             * TODO: in test.sql, this seems to work after create table, but not after drop table.
              */
             session.update_all_diagnostics().await;
 

--- a/crates/pgt_lsp/src/handlers/code_actions.rs
+++ b/crates/pgt_lsp/src/handlers/code_actions.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::Ordering;
-
 use crate::{adapters::get_cursor_position, session::Session};
 use anyhow::{Result, anyhow};
 use tower_lsp::lsp_types::{

--- a/crates/pgt_typecheck/src/lib.rs
+++ b/crates/pgt_typecheck/src/lib.rs
@@ -42,7 +42,14 @@ pub async fn check_sql(params: TypecheckParams<'_>) -> Option<TypecheckDiagnosti
         return None;
     }
 
-    let res = params.conn.prepare(params.sql).await;
+    let mut conn = match params.conn.acquire().await {
+        Ok(c) => c,
+        Err(_) => return None,
+    };
+
+    conn.close_on_drop();
+
+    let res = conn.prepare(params.sql).await;
 
     match res {
         Ok(_) => None,

--- a/crates/pgt_typecheck/src/lib.rs
+++ b/crates/pgt_typecheck/src/lib.rs
@@ -47,6 +47,10 @@ pub async fn check_sql(params: TypecheckParams<'_>) -> Option<TypecheckDiagnosti
         Err(_) => return None,
     };
 
+    // Postgres caches prepared statements within the current DB session (connection).
+    // This can cause issues if the underlying table schema changes while statements
+    // are cached. By closing the connection after use, we ensure a fresh state for
+    // each typecheck operation.
     conn.close_on_drop();
 
     let res = conn.prepare(params.sql).await;


### PR DESCRIPTION
I've been through many iterations but this seems to be the simplest.

We use a dedicated connection for the `prepare` statement and close it on drop. This will clear all the prepared statements for that session. `sqlx` itself doesn't cache anything when using `prepare`. If we worry about performance overhead, I suggest we a) use sqlx cache via `prepare_with` and b) debounce the publishing of diagnostics again 👍

