### PR TITLE
feat: request autocompletion without typing a letter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "tracing",
  "tree-sitter",
  "tree_sitter_sql",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,6 +1843,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,7 +2370,7 @@ dependencies = [
  "cc",
  "fs_extra",
  "glob",
- "itertools",
+ "itertools 0.10.5",
  "prost",
  "prost-build",
  "serde",
@@ -2759,6 +2768,7 @@ dependencies = [
  "futures",
  "globset",
  "ignore",
+ "itertools 0.14.0",
  "pgt_analyse",
  "pgt_analyser",
  "pgt_completions",
@@ -2999,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -3019,7 +3029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.90",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +776,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -899,6 +938,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1028,12 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -1514,6 +1595,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1662,12 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "hex"
@@ -1819,6 +1916,17 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.0",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2239,6 +2347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,6 +2566,7 @@ name = "pgt_completions"
 version = "0.0.0"
 dependencies = [
  "async-std",
+ "criterion",
  "pgt_schema_cache",
  "pgt_test_utils",
  "pgt_text_size",
@@ -2865,6 +2980,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,7 +3152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -3029,7 +3172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -4077,6 +4220,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/pgt_completions/Cargo.toml
+++ b/crates/pgt_completions/Cargo.toml
@@ -22,6 +22,7 @@ pgt_treesitter_queries.workspace = true
 schemars                         = { workspace = true, optional = true }
 serde                            = { workspace = true, features = ["derive"] }
 serde_json                       = { workspace = true }
+tracing                          = { workspace = true }
 tree-sitter.workspace            = true
 tree_sitter_sql.workspace        = true
 

--- a/crates/pgt_completions/Cargo.toml
+++ b/crates/pgt_completions/Cargo.toml
@@ -31,6 +31,7 @@ sqlx.workspace = true
 tokio = { version = "1.41.1", features = ["full"] }
 
 [dev-dependencies]
+criterion                = "0.5.1"
 pgt_test_utils.workspace = true
 
 [lib]
@@ -38,3 +39,7 @@ doctest = false
 
 [features]
 schema = ["dep:schemars"]
+
+[[bench]]
+harness = false
+name    = "sanitization"

--- a/crates/pgt_completions/benches/sanitization.rs
+++ b/crates/pgt_completions/benches/sanitization.rs
@@ -1,0 +1,249 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use pgt_completions::{CompletionParams, benchmark_sanitization};
+use pgt_schema_cache::SchemaCache;
+use pgt_text_size::TextSize;
+
+static CURSOR_POS: &str = "€";
+
+fn sql_and_pos(sql: &str) -> (String, usize) {
+    let pos = sql.find(CURSOR_POS).unwrap();
+    (sql.replace(CURSOR_POS, ""), pos)
+}
+
+fn get_tree(sql: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(tree_sitter_sql::language()).unwrap();
+    parser.parse(sql.to_string(), None).unwrap()
+}
+
+fn to_params<'a>(
+    text: String,
+    tree: &'a tree_sitter::Tree,
+    pos: usize,
+    cache: &'a SchemaCache,
+) -> CompletionParams<'a> {
+    let pos: u32 = pos.try_into().unwrap();
+    CompletionParams {
+        position: TextSize::new(pos),
+        schema: &cache,
+        text,
+        tree: Some(tree),
+    }
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("small sql, adjusted", |b| {
+        let content = format!("select {} from users;", CURSOR_POS);
+
+        let cache = SchemaCache::default();
+        let (sql, pos) = sql_and_pos(content.as_str());
+        let tree = get_tree(sql.as_str());
+
+        b.iter(|| benchmark_sanitization(black_box(to_params(sql.clone(), &tree, pos, &cache))));
+    });
+
+    c.bench_function("mid sql, adjusted", |b| {
+        let content = format!(
+            r#"select
+  n.oid :: int8 as "id!",
+  n.nspname as name,
+  u.rolname as "owner!"
+from
+  pg_namespace n,
+        {}
+where
+  n.nspowner = u.oid
+  and (
+    pg_has_role(n.nspowner, 'USAGE')
+    or has_schema_privilege(n.oid, 'CREATE, USAGE')
+  )
+  and not pg_catalog.starts_with(n.nspname, 'pg_temp_')
+  and not pg_catalog.starts_with(n.nspname, 'pg_toast_temp_');"#,
+            CURSOR_POS
+        );
+
+        let cache = SchemaCache::default();
+        let (sql, pos) = sql_and_pos(content.as_str());
+        let tree = get_tree(sql.as_str());
+
+        b.iter(|| benchmark_sanitization(black_box(to_params(sql.clone(), &tree, pos, &cache))));
+    });
+
+    c.bench_function("large sql, adjusted", |b| {
+        let content = format!(
+            r#"with
+  available_tables as (
+    select
+      c.relname as table_name,
+      c.oid as table_oid,
+      c.relkind as class_kind,
+      n.nspname as schema_name
+    from
+      pg_catalog.pg_class c
+      join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+    where
+      -- r: normal tables
+      -- v: views
+      -- m: materialized views
+      -- f: foreign tables
+      -- p: partitioned tables
+      c.relkind in ('r', 'v', 'm', 'f', 'p')
+  ),
+  available_indexes as (
+    select
+      unnest (ix.indkey) as attnum,
+      ix.indisprimary as is_primary,
+      ix.indisunique as is_unique,
+      ix.indrelid as table_oid
+    from
+        {}
+    where
+      c.relkind = 'i'
+  )
+select
+  atts.attname as name,
+  ts.table_name,
+  ts.table_oid :: int8 as "table_oid!",
+  ts.class_kind :: char as "class_kind!",
+  ts.schema_name,
+  atts.atttypid :: int8 as "type_id!",
+  not atts.attnotnull as "is_nullable!",
+  nullif(
+    information_schema._pg_char_max_length (atts.atttypid, atts.atttypmod),
+    -1
+  ) as varchar_length,
+  pg_get_expr (def.adbin, def.adrelid) as default_expr,
+  coalesce(ix.is_primary, false) as "is_primary_key!",
+  coalesce(ix.is_unique, false) as "is_unique!",
+  pg_catalog.col_description (ts.table_oid, atts.attnum) as comment
+from
+  pg_catalog.pg_attribute atts
+  join available_tables ts on atts.attrelid = ts.table_oid
+  left join available_indexes ix on atts.attrelid = ix.table_oid
+  and atts.attnum = ix.attnum
+  left join pg_catalog.pg_attrdef def on atts.attrelid = def.adrelid
+  and atts.attnum = def.adnum
+where
+  -- system columns, such as `cmax` or `tableoid`, have negative `attnum`s
+  atts.attnum >= 0;
+"#,
+            CURSOR_POS
+        );
+
+        let cache = SchemaCache::default();
+        let (sql, pos) = sql_and_pos(content.as_str());
+        let tree = get_tree(sql.as_str());
+
+        b.iter(|| benchmark_sanitization(black_box(to_params(sql.clone(), &tree, pos, &cache))));
+    });
+
+    c.bench_function("small sql, unadjusted", |b| {
+        let content = format!("select e{} from users;", CURSOR_POS);
+
+        let cache = SchemaCache::default();
+        let (sql, pos) = sql_and_pos(content.as_str());
+        let tree = get_tree(sql.as_str());
+
+        b.iter(|| benchmark_sanitization(black_box(to_params(sql.clone(), &tree, pos, &cache))));
+    });
+
+    c.bench_function("mid sql, unadjusted", |b| {
+        let content = format!(
+            r#"select
+  n.oid :: int8 as "id!",
+  n.nspname as name,
+  u.rolname as "owner!"
+from
+  pg_namespace n,
+  pg_r{}
+where
+  n.nspowner = u.oid
+  and (
+    pg_has_role(n.nspowner, 'USAGE')
+    or has_schema_privilege(n.oid, 'CREATE, USAGE')
+  )
+  and not pg_catalog.starts_with(n.nspname, 'pg_temp_')
+  and not pg_catalog.starts_with(n.nspname, 'pg_toast_temp_');"#,
+            CURSOR_POS
+        );
+
+        let cache = SchemaCache::default();
+        let (sql, pos) = sql_and_pos(content.as_str());
+        let tree = get_tree(sql.as_str());
+
+        b.iter(|| benchmark_sanitization(black_box(to_params(sql.clone(), &tree, pos, &cache))));
+    });
+
+    c.bench_function("large sql, unadjusted", |b| {
+        let content = format!(
+            r#"with
+  available_tables as (
+    select
+      c.relname as table_name,
+      c.oid as table_oid,
+      c.relkind as class_kind,
+      n.nspname as schema_name
+    from
+      pg_catalog.pg_class c
+      join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+    where
+      -- r: normal tables
+      -- v: views
+      -- m: materialized views
+      -- f: foreign tables
+      -- p: partitioned tables
+      c.relkind in ('r', 'v', 'm', 'f', 'p')
+  ),
+  available_indexes as (
+    select
+      unnest (ix.indkey) as attnum,
+      ix.indisprimary as is_primary,
+      ix.indisunique as is_unique,
+      ix.indrelid as table_oid
+    from
+      pg_catalog.pg_class c
+      join pg_catalog.pg_index ix on c.oid = ix.indexrelid
+    where
+      c.relkind = 'i'
+  )
+select
+  atts.attname as name,
+  ts.table_name,
+  ts.table_oid :: int8 as "table_oid!",
+  ts.class_kind :: char as "class_kind!",
+  ts.schema_name,
+  atts.atttypid :: int8 as "type_id!",
+  not atts.attnotnull as "is_nullable!",
+  nullif(
+    information_schema._pg_char_max_length (atts.atttypid, atts.atttypmod),
+    -1
+  ) as varchar_length,
+  pg_get_expr (def.adbin, def.adrelid) as default_expr,
+  coalesce(ix.is_primary, false) as "is_primary_key!",
+  coalesce(ix.is_unique, false) as "is_unique!",
+  pg_catalog.col_description (ts.table_oid, atts.attnum) as comment
+from
+  pg_catalog.pg_attribute atts
+  join available_tables ts on atts.attrelid = ts.table_oid
+  left join available_indexes ix on atts.attrelid = ix.table_oid
+  and atts.attnum = ix.attnum
+  left join pg_catalog.pg_attrdef def on atts.attrelid = def.adrelid
+  and atts.attnum = def.adnum
+where
+  -- system columns, such as `cmax` or `tableoid`, have negative `attnum`s
+  atts.attnum >= 0
+order by
+  sch{} "#,
+            CURSOR_POS
+        );
+
+        let cache = SchemaCache::default();
+        let (sql, pos) = sql_and_pos(content.as_str());
+        let tree = get_tree(sql.as_str());
+
+        b.iter(|| benchmark_sanitization(black_box(to_params(sql.clone(), &tree, pos, &cache))));
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/pgt_completions/src/complete.rs
+++ b/crates/pgt_completions/src/complete.rs
@@ -17,7 +17,10 @@ pub struct CompletionParams<'a> {
     pub tree: Option<&'a tree_sitter::Tree>,
 }
 
-#[tracing::instrument(level = "debug")]
+#[tracing::instrument(level = "debug", skip_all, fields(
+    text = params.text,
+    position = params.position.to_string()
+))]
 pub fn complete(params: CompletionParams) -> Vec<CompletionItem> {
     let ctx = CompletionContext::new(&params);
 

--- a/crates/pgt_completions/src/complete.rs
+++ b/crates/pgt_completions/src/complete.rs
@@ -17,6 +17,7 @@ pub struct CompletionParams<'a> {
     pub tree: Option<&'a tree_sitter::Tree>,
 }
 
+#[tracing::instrument(level = "debug")]
 pub fn complete(params: CompletionParams) -> Vec<CompletionItem> {
     let ctx = CompletionContext::new(&params);
 

--- a/crates/pgt_completions/src/complete.rs
+++ b/crates/pgt_completions/src/complete.rs
@@ -21,8 +21,45 @@ pub struct CompletionParams<'a> {
     text = params.text,
     position = params.position.to_string()
 ))]
-pub fn complete(params: CompletionParams) -> Vec<CompletionItem> {
-    let ctx = CompletionContext::new(&params);
+pub fn complete(mut params: CompletionParams) -> Vec<CompletionItem> {
+    let should_adjust_params = params.tree.is_some()
+        && (cursor_inbetween_nodes(params.tree.unwrap(), params.position)
+            || cursor_prepared_to_write_token_after_last_node(
+                params.tree.unwrap(),
+                params.position,
+            ));
+
+    let usable_sql = if should_adjust_params {
+        let pos: usize = params.position.into();
+
+        let mut mutated_sql = String::new();
+
+        for (idx, c) in params.text.chars().enumerate() {
+            if idx == pos {
+                mutated_sql.push_str("REPLACED_TOKEN ");
+            }
+            mutated_sql.push(c);
+        }
+
+        mutated_sql
+    } else {
+        params.text
+    };
+
+    let usable_tree = if should_adjust_params {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(tree_sitter_sql::language())
+            .expect("Error loading sql language");
+        parser.parse(usable_sql.clone(), None)
+    } else {
+        tracing::info!("We're reusing the previous tree.");
+        None
+    };
+
+    params.text = usable_sql;
+
+    let ctx = CompletionContext::new(&params, usable_tree.as_ref().or(params.tree));
 
     let mut builder = CompletionBuilder::new();
 
@@ -31,4 +68,88 @@ pub fn complete(params: CompletionParams) -> Vec<CompletionItem> {
     complete_columns(&ctx, &mut builder);
 
     builder.finish()
+}
+
+fn cursor_inbetween_nodes(tree: &tree_sitter::Tree, position: TextSize) -> bool {
+    let mut cursor = tree.walk();
+    let mut node = tree.root_node();
+
+    loop {
+        let child_dx = cursor.goto_first_child_for_byte(position.into());
+        if child_dx.is_none() {
+            break;
+        }
+        node = cursor.node();
+    }
+
+    let byte = position.into();
+
+    // Return true if the cursor is NOT within the node's bounds, INCLUSIVE
+    !(node.start_byte() <= byte && node.end_byte() >= byte)
+}
+
+fn cursor_prepared_to_write_token_after_last_node(
+    tree: &tree_sitter::Tree,
+    position: TextSize,
+) -> bool {
+    let cursor_pos: usize = position.into();
+    cursor_pos == tree.root_node().end_byte() + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use pgt_text_size::TextSize;
+
+    use crate::complete::{cursor_inbetween_nodes, cursor_prepared_to_write_token_after_last_node};
+
+    #[test]
+    fn test_cursor_inbetween_nodes() {
+        let input = "select  from users;";
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(tree_sitter_sql::language())
+            .expect("Error loading sql language");
+
+        let mut tree = parser.parse(input.to_string(), None).unwrap();
+
+        // select | from users;
+        assert!(cursor_inbetween_nodes(&mut tree, TextSize::new(7)));
+
+        // select  |from users;
+        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(8)));
+
+        // select|  from users;
+        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(6)));
+    }
+
+    #[test]
+    fn test_cursor_after_nodes() {
+        let input = "select * from ";
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(tree_sitter_sql::language())
+            .expect("Error loading sql language");
+
+        let mut tree = parser.parse(input.to_string(), None).unwrap();
+
+        // select * from|; <-- still on previous token
+        assert!(!cursor_prepared_to_write_token_after_last_node(
+            &mut tree,
+            TextSize::new(14)
+        ));
+
+        // select * from  |; <-- too far off
+        assert!(!cursor_prepared_to_write_token_after_last_node(
+            &mut tree,
+            TextSize::new(16)
+        ));
+
+        // select * from |; <-- just right
+        assert!(cursor_prepared_to_write_token_after_last_node(
+            &mut tree,
+            TextSize::new(15)
+        ));
+    }
 }

--- a/crates/pgt_completions/src/complete.rs
+++ b/crates/pgt_completions/src/complete.rs
@@ -5,6 +5,7 @@ use crate::{
     context::CompletionContext,
     item::CompletionItem,
     providers::{complete_columns, complete_functions, complete_tables},
+    sanitization::SanitizedCompletionParams,
 };
 
 pub const LIMIT: usize = 50;
@@ -21,45 +22,16 @@ pub struct CompletionParams<'a> {
     text = params.text,
     position = params.position.to_string()
 ))]
-pub fn complete(mut params: CompletionParams) -> Vec<CompletionItem> {
-    let should_adjust_params = params.tree.is_some()
-        && (cursor_inbetween_nodes(params.tree.unwrap(), params.position)
-            || cursor_prepared_to_write_token_after_last_node(
-                params.tree.unwrap(),
-                params.position,
-            ));
-
-    let usable_sql = if should_adjust_params {
-        let pos: usize = params.position.into();
-
-        let mut mutated_sql = String::new();
-
-        for (idx, c) in params.text.chars().enumerate() {
-            if idx == pos {
-                mutated_sql.push_str("REPLACED_TOKEN ");
-            }
-            mutated_sql.push(c);
+pub fn complete(params: CompletionParams) -> Vec<CompletionItem> {
+    let sanitized_params = match SanitizedCompletionParams::try_from(params) {
+        Ok(p) => p,
+        Err(err) => {
+            tracing::warn!("Not possible to get completions: {}", err);
+            return vec![];
         }
-
-        mutated_sql
-    } else {
-        params.text
     };
 
-    let usable_tree = if should_adjust_params {
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(tree_sitter_sql::language())
-            .expect("Error loading sql language");
-        parser.parse(usable_sql.clone(), None)
-    } else {
-        tracing::info!("We're reusing the previous tree.");
-        None
-    };
-
-    params.text = usable_sql;
-
-    let ctx = CompletionContext::new(&params, usable_tree.as_ref().or(params.tree));
+    let ctx = CompletionContext::new(&sanitized_params);
 
     let mut builder = CompletionBuilder::new();
 
@@ -68,88 +40,4 @@ pub fn complete(mut params: CompletionParams) -> Vec<CompletionItem> {
     complete_columns(&ctx, &mut builder);
 
     builder.finish()
-}
-
-fn cursor_inbetween_nodes(tree: &tree_sitter::Tree, position: TextSize) -> bool {
-    let mut cursor = tree.walk();
-    let mut node = tree.root_node();
-
-    loop {
-        let child_dx = cursor.goto_first_child_for_byte(position.into());
-        if child_dx.is_none() {
-            break;
-        }
-        node = cursor.node();
-    }
-
-    let byte = position.into();
-
-    // Return true if the cursor is NOT within the node's bounds, INCLUSIVE
-    !(node.start_byte() <= byte && node.end_byte() >= byte)
-}
-
-fn cursor_prepared_to_write_token_after_last_node(
-    tree: &tree_sitter::Tree,
-    position: TextSize,
-) -> bool {
-    let cursor_pos: usize = position.into();
-    cursor_pos == tree.root_node().end_byte() + 1
-}
-
-#[cfg(test)]
-mod tests {
-    use pgt_text_size::TextSize;
-
-    use crate::complete::{cursor_inbetween_nodes, cursor_prepared_to_write_token_after_last_node};
-
-    #[test]
-    fn test_cursor_inbetween_nodes() {
-        let input = "select  from users;";
-
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(tree_sitter_sql::language())
-            .expect("Error loading sql language");
-
-        let mut tree = parser.parse(input.to_string(), None).unwrap();
-
-        // select | from users;
-        assert!(cursor_inbetween_nodes(&mut tree, TextSize::new(7)));
-
-        // select  |from users;
-        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(8)));
-
-        // select|  from users;
-        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(6)));
-    }
-
-    #[test]
-    fn test_cursor_after_nodes() {
-        let input = "select * from ";
-
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(tree_sitter_sql::language())
-            .expect("Error loading sql language");
-
-        let mut tree = parser.parse(input.to_string(), None).unwrap();
-
-        // select * from|; <-- still on previous token
-        assert!(!cursor_prepared_to_write_token_after_last_node(
-            &mut tree,
-            TextSize::new(14)
-        ));
-
-        // select * from  |; <-- too far off
-        assert!(!cursor_prepared_to_write_token_after_last_node(
-            &mut tree,
-            TextSize::new(16)
-        ));
-
-        // select * from |; <-- just right
-        assert!(cursor_prepared_to_write_token_after_last_node(
-            &mut tree,
-            TextSize::new(15)
-        ));
-    }
 }

--- a/crates/pgt_completions/src/complete.rs
+++ b/crates/pgt_completions/src/complete.rs
@@ -23,13 +23,7 @@ pub struct CompletionParams<'a> {
     position = params.position.to_string()
 ))]
 pub fn complete(params: CompletionParams) -> Vec<CompletionItem> {
-    let sanitized_params = match SanitizedCompletionParams::try_from(params) {
-        Ok(p) => p,
-        Err(err) => {
-            tracing::warn!("Not possible to get completions: {}", err);
-            return vec![];
-        }
-    };
+    let sanitized_params = SanitizedCompletionParams::from(params);
 
     let ctx = CompletionContext::new(&sanitized_params);
 

--- a/crates/pgt_completions/src/context.rs
+++ b/crates/pgt_completions/src/context.rs
@@ -81,6 +81,8 @@ impl<'a> CompletionContext<'a> {
         ctx.gather_tree_context();
         ctx.gather_info_from_ts_queries();
 
+        println!("Here's my node: {:?}", ctx.ts_node.unwrap());
+
         ctx
     }
 

--- a/crates/pgt_completions/src/context.rs
+++ b/crates/pgt_completions/src/context.rs
@@ -85,10 +85,7 @@ impl<'a> CompletionContext<'a> {
             mentioned_relations: HashMap::new(),
         };
 
-        tracing::warn!("gathering tree context");
         ctx.gather_tree_context();
-
-        tracing::warn!("gathering info from ts query");
         ctx.gather_info_from_ts_queries();
 
         ctx

--- a/crates/pgt_completions/src/lib.rs
+++ b/crates/pgt_completions/src/lib.rs
@@ -4,6 +4,7 @@ mod context;
 mod item;
 mod providers;
 mod relevance;
+mod sanitization;
 
 #[cfg(test)]
 mod test_helper;

--- a/crates/pgt_completions/src/lib.rs
+++ b/crates/pgt_completions/src/lib.rs
@@ -11,3 +11,4 @@ mod test_helper;
 
 pub use complete::*;
 pub use item::*;
+pub use sanitization::*;

--- a/crates/pgt_completions/src/providers/tables.rs
+++ b/crates/pgt_completions/src/providers/tables.rs
@@ -73,8 +73,8 @@ mod tests {
         "#;
 
         let test_cases = vec![
-            (format!("select * from us{}", CURSOR_POS), "users"),
-            (format!("select * from em{}", CURSOR_POS), "emails"),
+            // (format!("select * from us{}", CURSOR_POS), "users"),
+            // (format!("select * from em{}", CURSOR_POS), "emails"),
             (format!("select * from {}", CURSOR_POS), "addresses"),
         ];
 

--- a/crates/pgt_completions/src/providers/tables.rs
+++ b/crates/pgt_completions/src/providers/tables.rs
@@ -73,15 +73,14 @@ mod tests {
         "#;
 
         let test_cases = vec![
-            // (format!("select * from us{}", CURSOR_POS), "users"),
-            // (format!("select * from em{}", CURSOR_POS), "emails"),
-            (format!("select * from {}", CURSOR_POS), "addresses"),
+            (format!("select * from u{}", CURSOR_POS), "users"),
+            (format!("select * from e{}", CURSOR_POS), "emails"),
+            (format!("select * from a{}", CURSOR_POS), "addresses"),
         ];
 
         for (query, expected_label) in test_cases {
             let (tree, cache) = get_test_deps(setup, query.as_str().into()).await;
             let params = get_test_params(&tree, &cache, query.as_str().into());
-            println!("{}, {}", &params.text, &params.position);
             let items = complete(params);
 
             assert!(!items.is_empty());

--- a/crates/pgt_completions/src/providers/tables.rs
+++ b/crates/pgt_completions/src/providers/tables.rs
@@ -81,6 +81,7 @@ mod tests {
         for (query, expected_label) in test_cases {
             let (tree, cache) = get_test_deps(setup, query.as_str().into()).await;
             let params = get_test_params(&tree, &cache, query.as_str().into());
+            println!("{}, {}", &params.text, &params.position);
             let items = complete(params);
 
             assert!(!items.is_empty());

--- a/crates/pgt_completions/src/relevance.rs
+++ b/crates/pgt_completions/src/relevance.rs
@@ -41,7 +41,10 @@ impl CompletionRelevance<'_> {
     }
 
     fn check_matches_query_input(&mut self, ctx: &CompletionContext) {
-        let node = ctx.ts_node.unwrap();
+        let node = match ctx.node_under_cursor {
+            Some(node) => node,
+            None => return,
+        };
 
         let content = match ctx.get_ts_node_content(node) {
             Some(c) => c,

--- a/crates/pgt_completions/src/relevance.rs
+++ b/crates/pgt_completions/src/relevance.rs
@@ -57,10 +57,7 @@ impl CompletionRelevance<'_> {
         let name = match self.data {
             CompletionRelevanceData::Function(f) => f.name.as_str(),
             CompletionRelevanceData::Table(t) => t.name.as_str(),
-            CompletionRelevanceData::Column(c) => {
-                //
-                c.name.as_str()
-            }
+            CompletionRelevanceData::Column(c) => c.name.as_str(),
         };
 
         if name.starts_with(content) {

--- a/crates/pgt_completions/src/relevance.rs
+++ b/crates/pgt_completions/src/relevance.rs
@@ -1,4 +1,4 @@
-use crate::context::{ClauseType, CompletionContext};
+use crate::context::{ClauseType, CompletionContext, NodeText};
 
 #[derive(Debug)]
 pub(crate) enum CompletionRelevanceData<'a> {
@@ -47,7 +47,10 @@ impl CompletionRelevance<'_> {
         };
 
         let content = match ctx.get_ts_node_content(node) {
-            Some(c) => c,
+            Some(c) => match c {
+                NodeText::Original(s) => s,
+                NodeText::Replaced => return,
+            },
             None => return,
         };
 

--- a/crates/pgt_completions/src/sanitization.rs
+++ b/crates/pgt_completions/src/sanitization.rs
@@ -16,20 +16,18 @@ pub fn benchmark_sanitization(params: CompletionParams) -> String {
     params.text
 }
 
-impl<'larger, 'smaller> TryFrom<CompletionParams<'larger>> for SanitizedCompletionParams<'smaller>
+impl<'larger, 'smaller> From<CompletionParams<'larger>> for SanitizedCompletionParams<'smaller>
 where
     'larger: 'smaller,
 {
-    type Error = String;
-
-    fn try_from(params: CompletionParams<'larger>) -> Result<Self, Self::Error> {
+    fn from(params: CompletionParams<'larger>) -> Self {
         if cursor_inbetween_nodes(params.tree, params.position)
             || cursor_prepared_to_write_token_after_last_node(params.tree, params.position)
             || cursor_before_semicolon(params.tree, params.position)
         {
-            Ok(SanitizedCompletionParams::with_adjusted_sql(params))
+            SanitizedCompletionParams::with_adjusted_sql(params)
         } else {
-            Ok(SanitizedCompletionParams::unadjusted(params))
+            SanitizedCompletionParams::unadjusted(params)
         }
     }
 }

--- a/crates/pgt_completions/src/sanitization.rs
+++ b/crates/pgt_completions/src/sanitization.rs
@@ -1,0 +1,284 @@
+use std::borrow::Cow;
+
+use pgt_text_size::TextSize;
+
+use crate::CompletionParams;
+
+pub(crate) struct SanitizedCompletionParams<'a> {
+    pub position: TextSize,
+    pub text: String,
+    pub schema: &'a pgt_schema_cache::SchemaCache,
+    pub tree: Cow<'a, tree_sitter::Tree>,
+}
+
+impl<'larger, 'smaller> TryFrom<CompletionParams<'larger>> for SanitizedCompletionParams<'smaller>
+where
+    'larger: 'smaller,
+{
+    type Error = String;
+
+    fn try_from(params: CompletionParams<'larger>) -> Result<Self, Self::Error> {
+        let tree = match &params.tree {
+            Some(tree) => tree,
+            None => return Err("Tree required for autocompletions.".to_string()),
+        };
+
+        if cursor_inbetween_nodes(tree, params.position)
+            || cursor_prepared_to_write_token_after_last_node(tree, params.position)
+        {
+            Ok(SanitizedCompletionParams::with_adjusted_sql(params))
+        } else {
+            Ok(SanitizedCompletionParams::unadjusted(params))
+        }
+    }
+}
+
+static SANITIZED_TOKEN: &str = "REPLACED_TOKEN";
+
+impl<'larger, 'smaller> SanitizedCompletionParams<'smaller>
+where
+    'larger: 'smaller,
+{
+    fn with_adjusted_sql(params: CompletionParams<'larger>) -> Self {
+        let cursor_pos: usize = params.position.into();
+        let mut sql = String::new();
+
+        for (idx, c) in params.text.chars().enumerate() {
+            if idx == cursor_pos {
+                sql.push_str(SANITIZED_TOKEN);
+                sql.push(' ');
+            }
+            sql.push(c);
+        }
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(tree_sitter_sql::language())
+            .expect("Error loading sql language");
+        let tree = parser.parse(sql.clone(), None).unwrap();
+
+        Self {
+            position: params.position,
+            text: sql,
+            schema: params.schema,
+            tree: Cow::Owned(tree),
+        }
+    }
+    fn unadjusted(params: CompletionParams<'larger>) -> Self {
+        Self {
+            position: params.position,
+            text: params.text.clone(),
+            schema: params.schema,
+            tree: Cow::Borrowed(params.tree.unwrap()),
+        }
+    }
+
+    pub fn is_sanitized_token(txt: &str) -> bool {
+        txt == SANITIZED_TOKEN
+    }
+}
+
+/// Checks if the cursor is positioned inbetween two SQL nodes.
+///
+/// ```sql
+/// select| from users; -- cursor "touches" select node. returns false.
+/// select |from users; -- cursor "touches" from node. returns false.
+/// select | from users; -- cursor is between select and from nodes. returns true.
+/// ```
+fn cursor_inbetween_nodes(tree: &tree_sitter::Tree, position: TextSize) -> bool {
+    let mut cursor = tree.walk();
+    let mut leaf_node = tree.root_node();
+
+    let byte = position.into();
+
+    // if the cursor escapes the root node, it can't be between nodes.
+    if byte < leaf_node.start_byte() || byte >= leaf_node.end_byte() {
+        return false;
+    }
+
+    /*
+     * Get closer and closer to the leaf node, until
+     *  a) there is no more child *for the node* or
+     *  b) there is no more child *under the cursor*.
+     */
+    loop {
+        let child_idx = cursor.goto_first_child_for_byte(position.into());
+        if child_idx.is_none() {
+            break;
+        }
+        leaf_node = cursor.node();
+    }
+
+    let cursor_on_leafnode = byte >= leaf_node.start_byte() && leaf_node.end_byte() >= byte;
+
+    /*
+     * The cursor is inbetween nodes if it is not within the range
+     * of a leaf node.
+     */
+    !cursor_on_leafnode
+}
+
+/// Checks if the cursor is positioned after the last node,
+/// ready to write the next token:
+///
+/// ```sql
+/// select * from |   -- ready to write!
+/// select * from|    -- user still needs to type a space
+/// select * from  |  -- too far off.
+/// ```
+fn cursor_prepared_to_write_token_after_last_node(
+    tree: &tree_sitter::Tree,
+    position: TextSize,
+) -> bool {
+    let cursor_pos: usize = position.into();
+    cursor_pos == tree.root_node().end_byte() + 1
+}
+
+fn cursor_before_or_on_semicolon(tree: &tree_sitter::Tree, position: TextSize) -> bool {
+    let mut cursor = tree.walk();
+    let mut leaf_node = tree.root_node();
+
+    let byte: usize = position.into();
+
+    // if the cursor escapes the root node, it can't be between nodes.
+    if byte < leaf_node.start_byte() || byte >= leaf_node.end_byte() {
+        return false;
+    }
+
+    loop {
+        let child_idx = cursor.goto_first_child_for_byte(position.into());
+        if child_idx.is_none() {
+            break;
+        }
+        leaf_node = cursor.node();
+    }
+
+    // The semicolon node is on the same level as the statement:
+    //
+    // program [0..26]
+    //   statement [0..19]
+    //   ; [25..26]
+    //
+    // However, if we search for position 21, we'll still land on the semi node.
+    // We must manually verify that the cursor is between the statement and the semi nodes.
+
+    // if the last node is not a semi, the statement is not completed.
+    if leaf_node.kind() != ";" {
+        return false;
+    }
+
+    // not okay to be on the semi.
+    if byte == leaf_node.start_byte() {
+        return false;
+    }
+
+    leaf_node
+        .prev_named_sibling()
+        .map(|n| n.end_byte() < byte)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use pgt_text_size::TextSize;
+
+    use crate::sanitization::{
+        cursor_before_or_on_semicolon, cursor_inbetween_nodes,
+        cursor_prepared_to_write_token_after_last_node,
+    };
+
+    #[test]
+    fn test_cursor_inbetween_nodes() {
+        // note: two spaces between select and from.
+        let input = "select  from users;";
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(tree_sitter_sql::language())
+            .expect("Error loading sql language");
+
+        let mut tree = parser.parse(input.to_string(), None).unwrap();
+
+        // select | from users; <-- just right, one space after select token, one space before from
+        assert!(cursor_inbetween_nodes(&mut tree, TextSize::new(7)));
+
+        // select|  from users; <-- still on select token
+        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(6)));
+
+        // select  |from users; <-- already on from token
+        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(8)));
+
+        // select from users;|
+        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(19)));
+    }
+
+    #[test]
+    fn test_cursor_after_nodes() {
+        let input = "select * from";
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(tree_sitter_sql::language())
+            .expect("Error loading sql language");
+
+        let mut tree = parser.parse(input.to_string(), None).unwrap();
+
+        // select * from| <-- still on previous token
+        assert!(!cursor_prepared_to_write_token_after_last_node(
+            &mut tree,
+            TextSize::new(13)
+        ));
+
+        // select * from  | <-- too far off, two spaces afterward
+        assert!(!cursor_prepared_to_write_token_after_last_node(
+            &mut tree,
+            TextSize::new(15)
+        ));
+
+        // select * |from  <-- it's within
+        assert!(!cursor_prepared_to_write_token_after_last_node(
+            &mut tree,
+            TextSize::new(9)
+        ));
+
+        // select * from | <-- just right
+        assert!(cursor_prepared_to_write_token_after_last_node(
+            &mut tree,
+            TextSize::new(14)
+        ));
+    }
+
+    #[test]
+    fn test_cursor_before_semicolon() {
+        // Idx "13" is the exlusive end of `select * from` (first space after from)
+        // Idx "18" is right where the semi is
+        let input = "select * from     ;";
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(tree_sitter_sql::language())
+            .expect("Error loading sql language");
+
+        let mut tree = parser.parse(input.to_string(), None).unwrap();
+
+        // select * from     ;| <-- it's after the statement
+        assert!(!cursor_before_or_on_semicolon(&mut tree, TextSize::new(19)));
+
+        // select * from|    ; <-- still touches the from
+        assert!(!cursor_before_or_on_semicolon(&mut tree, TextSize::new(13)));
+
+        // not okay to be ON the semi.
+        // select * from     |;
+        assert!(!cursor_before_or_on_semicolon(&mut tree, TextSize::new(18)));
+
+        // anything is fine here
+        // select * from |   ;
+        // select * from  |  ;
+        // select * from   | ;
+        // select * from    |;
+        assert!(cursor_before_or_on_semicolon(&mut tree, TextSize::new(14)));
+        assert!(cursor_before_or_on_semicolon(&mut tree, TextSize::new(15)));
+        assert!(cursor_before_or_on_semicolon(&mut tree, TextSize::new(16)));
+        assert!(cursor_before_or_on_semicolon(&mut tree, TextSize::new(17)));
+    }
+}

--- a/crates/pgt_completions/src/sanitization.rs
+++ b/crates/pgt_completions/src/sanitization.rs
@@ -25,6 +25,7 @@ where
 
         if cursor_inbetween_nodes(tree, params.position)
             || cursor_prepared_to_write_token_after_last_node(tree, params.position)
+            || cursor_before_semicolon(tree, params.position)
         {
             Ok(SanitizedCompletionParams::with_adjusted_sql(params))
         } else {
@@ -134,7 +135,7 @@ fn cursor_prepared_to_write_token_after_last_node(
     cursor_pos == tree.root_node().end_byte() + 1
 }
 
-fn cursor_before_or_on_semicolon(tree: &tree_sitter::Tree, position: TextSize) -> bool {
+fn cursor_before_semicolon(tree: &tree_sitter::Tree, position: TextSize) -> bool {
     let mut cursor = tree.walk();
     let mut leaf_node = tree.root_node();
 
@@ -183,7 +184,7 @@ mod tests {
     use pgt_text_size::TextSize;
 
     use crate::sanitization::{
-        cursor_before_or_on_semicolon, cursor_inbetween_nodes,
+        cursor_before_semicolon, cursor_inbetween_nodes,
         cursor_prepared_to_write_token_after_last_node,
     };
 
@@ -262,23 +263,23 @@ mod tests {
         let mut tree = parser.parse(input.to_string(), None).unwrap();
 
         // select * from     ;| <-- it's after the statement
-        assert!(!cursor_before_or_on_semicolon(&mut tree, TextSize::new(19)));
+        assert!(!cursor_before_semicolon(&mut tree, TextSize::new(19)));
 
         // select * from|    ; <-- still touches the from
-        assert!(!cursor_before_or_on_semicolon(&mut tree, TextSize::new(13)));
+        assert!(!cursor_before_semicolon(&mut tree, TextSize::new(13)));
 
         // not okay to be ON the semi.
         // select * from     |;
-        assert!(!cursor_before_or_on_semicolon(&mut tree, TextSize::new(18)));
+        assert!(!cursor_before_semicolon(&mut tree, TextSize::new(18)));
 
         // anything is fine here
         // select * from |   ;
         // select * from  |  ;
         // select * from   | ;
         // select * from    |;
-        assert!(cursor_before_or_on_semicolon(&mut tree, TextSize::new(14)));
-        assert!(cursor_before_or_on_semicolon(&mut tree, TextSize::new(15)));
-        assert!(cursor_before_or_on_semicolon(&mut tree, TextSize::new(16)));
-        assert!(cursor_before_or_on_semicolon(&mut tree, TextSize::new(17)));
+        assert!(cursor_before_semicolon(&mut tree, TextSize::new(14)));
+        assert!(cursor_before_semicolon(&mut tree, TextSize::new(15)));
+        assert!(cursor_before_semicolon(&mut tree, TextSize::new(16)));
+        assert!(cursor_before_semicolon(&mut tree, TextSize::new(17)));
     }
 }

--- a/crates/pgt_completions/src/sanitization.rs
+++ b/crates/pgt_completions/src/sanitization.rs
@@ -11,6 +11,11 @@ pub(crate) struct SanitizedCompletionParams<'a> {
     pub tree: Cow<'a, tree_sitter::Tree>,
 }
 
+pub fn benchmark_sanitization(params: CompletionParams) -> String {
+    let params: SanitizedCompletionParams = params.try_into().unwrap();
+    params.text
+}
+
 impl<'larger, 'smaller> TryFrom<CompletionParams<'larger>> for SanitizedCompletionParams<'smaller>
 where
     'larger: 'smaller,

--- a/crates/pgt_completions/src/test_helper.rs
+++ b/crates/pgt_completions/src/test_helper.rs
@@ -15,8 +15,10 @@ impl From<&str> for InputQuery {
     fn from(value: &str) -> Self {
         let position = value
             .find(CURSOR_POS)
-            .map(|p| p.saturating_sub(1))
+            .map(|p| p.saturating_add(1))
             .expect("Insert Cursor Position into your Query.");
+
+        println!("{}", position);
 
         InputQuery {
             sql: value.replace(CURSOR_POS, ""),

--- a/crates/pgt_text_size/src/range.rs
+++ b/crates/pgt_text_size/src/range.rs
@@ -281,6 +281,24 @@ impl TextRange {
         })
     }
 
+    /// Expand the range's end by the given offset.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use pgt_text_size::*;
+    /// assert_eq!(
+    ///     TextRange::new(2.into(), 4.into()).checked_expand_end(16.into()).unwrap(),
+    ///     TextRange::new(2.into(), 20.into()),
+    /// );
+    /// ```
+    #[inline]
+    pub fn checked_expand_end(self, offset: TextSize) -> Option<TextRange> {
+        Some(TextRange {
+            start: self.start,
+            end: self.end.checked_add(offset)?,
+        })
+    }
     /// Subtract an offset from this range.
     ///
     /// Note that this is not appropriate for changing where a `TextRange` is

--- a/crates/pgt_workspace/Cargo.toml
+++ b/crates/pgt_workspace/Cargo.toml
@@ -18,6 +18,7 @@ futures           = "0.3.31"
 globset           = "0.4.16"
 
 ignore                    = { workspace = true }
+itertools                 = { version = "0.14.0" }
 pgt_analyse               = { workspace = true, features = ["serde"] }
 pgt_analyser              = { workspace = true }
 pgt_completions           = { workspace = true }

--- a/crates/pgt_workspace/src/features/completions.rs
+++ b/crates/pgt_workspace/src/features/completions.rs
@@ -1,6 +1,9 @@
+use itertools::Itertools;
 use pgt_completions::CompletionItem;
 use pgt_fs::PgTPath;
-use pgt_text_size::TextSize;
+use pgt_text_size::{TextRange, TextSize};
+
+use crate::workspace::{Document, Statement, StatementId};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -22,5 +25,58 @@ impl IntoIterator for CompletionsResult {
     type IntoIter = <Vec<CompletionItem> as IntoIterator>::IntoIter;
     fn into_iter(self) -> Self::IntoIter {
         self.items.into_iter()
+    }
+}
+
+pub(crate) fn get_statement_for_completions<'a>(
+    doc: &'a Document,
+    position: TextSize,
+) -> Option<(Statement, &'a TextRange, &'a str)> {
+    let count = doc.statement_count();
+    // no arms no cookies
+    if count == 0 {
+        return None;
+    }
+
+    /*
+     * We allow an offset of two for the statement:
+     *
+     * select * from | <-- we want to suggest items for the next token.
+     *
+     * However, if the current statement is terminated by a semicolon, we don't apply any
+     * offset.
+     *
+     * select * from users; | <-- no autocompletions here.
+     */
+    let matches_expanding_range = |stmt_id: StatementId, range: &TextRange, position: TextSize| {
+        let measuring_range = if doc.is_terminated_by_semicolon(stmt_id).unwrap() {
+            *range
+        } else {
+            range.checked_expand_end(2.into()).unwrap_or(*range)
+        };
+        measuring_range.contains(position)
+    };
+
+    if count == 1 {
+        let (stmt, range, txt) = doc.iter_statements_with_text_and_range().next().unwrap();
+        if matches_expanding_range(stmt.id, range, position) {
+            Some((stmt, range, txt))
+        } else {
+            None
+        }
+    } else {
+        /*
+         * If we have multiple statements, we want to make sure that we do not overlap
+         * with the next one.
+         *
+         * select 1 |select 1;
+         */
+        let mut stmts = doc.iter_statements_with_text_and_range().tuple_windows();
+        stmts
+            .find(|((current_stmt, rcurrent, _), (_, rnext, _))| {
+                let overlaps_next = rnext.contains(position);
+                matches_expanding_range(current_stmt.id, rcurrent, position) && !overlaps_next
+            })
+            .map(|t| t.0)
     }
 }

--- a/crates/pgt_workspace/src/workspace.rs
+++ b/crates/pgt_workspace/src/workspace.rs
@@ -21,7 +21,7 @@ use crate::{
 mod client;
 mod server;
 
-pub(crate) use server::StatementId;
+pub(crate) use server::document::{Document, Statement, StatementId};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/crates/pgt_workspace/src/workspace/server/document.rs
+++ b/crates/pgt_workspace/src/workspace/server/document.rs
@@ -117,6 +117,16 @@ impl Document {
                 stmt.to_owned()
             })
     }
+
+    pub fn is_terminated_by_semicolon(&self, stmt_id: StatementId) -> Option<bool> {
+        self.positions
+            .iter()
+            .find(|pos| pos.0 == stmt_id)
+            .map(|(_, range)| {
+                let final_char = self.content.chars().nth(range.end().into());
+                final_char == Some(';')
+            })
+    }
 }
 
 pub(crate) struct IdGenerator {

--- a/crates/pgt_workspace/src/workspace/server/document.rs
+++ b/crates/pgt_workspace/src/workspace/server/document.rs
@@ -104,6 +104,10 @@ impl Document {
         })
     }
 
+    pub fn statement_count(&self) -> usize {
+        self.positions.len()
+    }
+
     pub fn get_txt(&self, stmt_id: StatementId) -> Option<String> {
         self.positions
             .iter()

--- a/crates/pgt_workspace/src/workspace/server/document.rs
+++ b/crates/pgt_workspace/src/workspace/server/document.rs
@@ -123,7 +123,8 @@ impl Document {
             .iter()
             .find(|pos| pos.0 == stmt_id)
             .map(|(_, range)| {
-                let final_char = self.content.chars().nth(range.end().into());
+                let length: usize = range.end().into();
+                let final_char = self.content.chars().nth(length - 1);
                 final_char == Some(';')
             })
     }

--- a/postgrestools.jsonc
+++ b/postgrestools.jsonc
@@ -17,7 +17,7 @@
   // YOU CAN COMMENT ME OUT :)
   "db": {
     "host": "127.0.0.1",
-    "port": 5432,
+    "port": 54322,
     "username": "postgres",
     "password": "postgres",
     "database": "postgres",

--- a/postgrestools.jsonc
+++ b/postgrestools.jsonc
@@ -17,7 +17,7 @@
   // YOU CAN COMMENT ME OUT :)
   "db": {
     "host": "127.0.0.1",
-    "port": 54322,
+    "port": 5432,
     "username": "postgres",
     "password": "postgres",
     "database": "postgres",


### PR DESCRIPTION
So far, we were relying on complete tree-sitter trees for autocompletion.

This works fine if you type the first letter of a node, say:
`select * from u|` 
Now, the `u` is considered a table node, and we can look for tables.

But this PR makes it such that we can also request completions if we haven't typed the `u` yet.

It does so by checking whether the tree is valid and, if not, injecting a token to fix the tree-sitter tree.

Additionally, in the case of `select * from |`, the workspace would consider the cursor to be outside the statement. I added a little offset so the cursor still matches a statement if it's 2 characters after the last token.