### PR TITLE
feat: allow configuration through workspace/didChangeConfiguration

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -8,7 +8,7 @@
 	"files": {
 		"ignoreUnknown": false,
 		"ignore": [],
-		"include": ["packages/**/*"]
+		"include": ["/packages/**/*"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/crates/pgt_configuration/src/lib.rs
+++ b/crates/pgt_configuration/src/lib.rs
@@ -22,6 +22,7 @@ pub use analyser::{
     RulePlainConfiguration, RuleSelector, RuleWithFixOptions, RuleWithOptions, Rules,
     partial_linter_configuration,
 };
+use biome_deserialize::Merge;
 use biome_deserialize_macros::{Merge, Partial};
 use bpaf::Bpaf;
 use database::{
@@ -115,6 +116,11 @@ impl PartialConfiguration {
                 disable_connection: Some(false),
             }),
         }
+    }
+
+    pub fn merge(&mut self, other: Self) -> Self {
+        self.merge_with(other);
+        self.clone()
     }
 }
 

--- a/crates/pgt_configuration/src/lib.rs
+++ b/crates/pgt_configuration/src/lib.rs
@@ -22,7 +22,6 @@ pub use analyser::{
     RulePlainConfiguration, RuleSelector, RuleWithFixOptions, RuleWithOptions, Rules,
     partial_linter_configuration,
 };
-use biome_deserialize::Merge;
 use biome_deserialize_macros::{Merge, Partial};
 use bpaf::Bpaf;
 use database::{
@@ -116,11 +115,6 @@ impl PartialConfiguration {
                 disable_connection: Some(false),
             }),
         }
-    }
-
-    pub fn merge(&mut self, other: Self) -> Self {
-        self.merge_with(other);
-        self.clone()
     }
 }
 

--- a/crates/pgt_lsp/src/session.rs
+++ b/crates/pgt_lsp/src/session.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use pgt_analyse::RuleCategoriesBuilder;
-use pgt_configuration::ConfigurationPathHint;
+use pgt_configuration::{ConfigurationPathHint, PartialConfiguration};
 use pgt_diagnostics::{DiagnosticExt, Error};
 use pgt_fs::{FileSystem, PgTPath};
 use pgt_workspace::Workspace;
@@ -386,11 +386,11 @@ impl Session {
     /// This function attempts to read the `postgrestools.jsonc` configuration file from
     /// the root URI and update the workspace settings accordingly
     #[tracing::instrument(level = "trace", skip(self))]
-    pub(crate) async fn load_workspace_settings(&self) {
+    pub(crate) async fn load_workspace_settings(&self, params: Option<PartialConfiguration>) {
         // Providing a custom configuration path will not allow to support workspaces
         if let Some(config_path) = &self.config_path {
             let base_path = ConfigurationPathHint::FromUser(config_path.clone());
-            let status = self.load_pgt_configuration_file(base_path).await;
+            let status = self.load_pgt_configuration_file(base_path, params).await;
             self.set_configuration_status(status);
         } else if let Some(folders) = self.get_workspace_folders() {
             info!("Detected workspace folder.");
@@ -401,9 +401,10 @@ impl Session {
                 match base_path {
                     Ok(base_path) => {
                         let status = self
-                            .load_pgt_configuration_file(ConfigurationPathHint::FromWorkspace(
-                                base_path,
-                            ))
+                            .load_pgt_configuration_file(
+                                ConfigurationPathHint::FromWorkspace(base_path),
+                                params.clone(),
+                            )
                             .await;
                         self.set_configuration_status(status);
                     }
@@ -420,7 +421,7 @@ impl Session {
                 None => ConfigurationPathHint::default(),
                 Some(path) => ConfigurationPathHint::FromLsp(path),
             };
-            let status = self.load_pgt_configuration_file(base_path).await;
+            let status = self.load_pgt_configuration_file(base_path, params).await;
             self.set_configuration_status(status);
         }
     }
@@ -428,6 +429,7 @@ impl Session {
     async fn load_pgt_configuration_file(
         &self,
         base_path: ConfigurationPathHint,
+        extra_config: Option<PartialConfiguration>,
     ) -> ConfigurationStatus {
         match load_configuration(&self.fs, base_path.clone()) {
             Ok(loaded_configuration) => {
@@ -446,7 +448,10 @@ impl Session {
                     Ok((vcs_base_path, gitignore_matches)) => {
                         let result = self.workspace.update_settings(UpdateSettingsParams {
                             workspace_directory: self.fs.working_directory(),
-                            configuration: fs_configuration,
+                            configuration: match extra_config {
+                                Some(config) => fs_configuration.clone().merge(config),
+                                None => fs_configuration,
+                            },
                             vcs_base_path,
                             gitignore_matches,
                         });

--- a/crates/pgt_workspace/src/workspace/server.rs
+++ b/crates/pgt_workspace/src/workspace/server.rs
@@ -167,6 +167,7 @@ impl Workspace for WorkspaceServer {
         )?;
 
         tracing::info!("Updated settings in workspace");
+        tracing::debug!("Updated settings are {:#?}", self.settings());
 
         self.connection
             .write()


### PR DESCRIPTION
## What kind of change does this PR introduce?

It enables passing workspace settings via the workspace/didChangeConfiguration notification. This in turn enables the client to specify settings dynamically, rather than being limited to configuration files. This is _a_ solution to #302. See example usage (with lspconfig) here: https://github.com/willruggiano/neovim.drv/commit/9aa06ad7c889ed7b14d35ab34264e757d5ad1a7e.

## What is the current behavior?

There is none. The payload of this handler is currently ignored.

## What is the new behavior?

The configuration received by the handler is merged with the fs configuration.
