### PR TITLE
fix: downgrade runners

### DIFF
--- a/.github/workflows/publish.reusable.yml
+++ b/.github/workflows/publish.reusable.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      # ? what's this?! required for executing the node script?
       id-token: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -102,10 +102,10 @@ jobs:
           version: latest
       - name: Run Lints
         run: |
+          cargo sqlx prepare --check --workspace
           cargo clippy
           cargo run -p rules_check
           biome lint
-          cargo sqlx prepare --check --workspace
 
   test:
     name: Test
@@ -113,9 +113,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # reactive once we upgrade to the latest version of pg_query that is windows-compatible
-          - os: windows-latest
-          - os: ubuntu-latest
+          # use the same images we use for compiling
+          - os: windows-2022
+          - os: ubuntu-22.04
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
@@ -138,8 +138,10 @@ jobs:
         run: cargo test --workspace
 
   test-js-bindings:
-    name: Test JS Bindings
-    runs-on: ubuntu-latest
+    name:
+      Test JS Bindings
+      # use the same image we use for compiling
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:latest
@@ -173,7 +175,7 @@ jobs:
 
   codegen:
     name: Check Codegen
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,12 @@ jobs:
     strategy:
       matrix:
         config:
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu }
-          - { os: macos-latest, target: x86_64-apple-darwin }
-          - { os: macos-latest, target: aarch64-apple-darwin }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc }
-          - { os: windows-latest, target: aarch64-pc-windows-msvc }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu }
+          - { os: macos-14, target: x86_64-apple-darwin }
+          - { os: macos-14, target: aarch64-apple-darwin }
+          - { os: windows-2022, target: x86_64-pc-windows-msvc }
+          - { os: windows-2022, target: aarch64-pc-windows-msvc }
 
     runs-on: ${{ matrix.config.os }}
 
@@ -87,12 +87,12 @@ jobs:
 
       # windows is a special snowflake too, it saves binaries as .exe
       - name: 👦 Name the Binary
-        if: matrix.config.os == 'windows-latest'
+        if: matrix.config.os == 'windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.config.target }}/release/postgrestools.exe ./dist/postgrestools_${{ matrix.config.target }}
       - name: 👦 Name the Binary
-        if: matrix.config.os != 'windows-latest'
+        if: matrix.config.os != 'windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.config.target }}/release/postgrestools ./dist/postgrestools_${{ matrix.config.target }}


### PR DESCRIPTION
Downgrades runners wherever we need to build the binary.

When I checked with Docker, Ubuntu-22.04 had glibc version 2.35, so that should help #280 
