### PR TITLE
fix: release changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
         id: create_changelog
         with:
           config: cliff.toml
-          args: --bump
+          args: --bump --latest
         env:
           GITHUB_REPO: ${{ github.repository }}
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -8,14 +8,14 @@
 [changelog]
 # template for the changelog header
 header = """
-# Changelog\n
-All notable changes to this project will be documented in this file.\n
+# Postgres Language Server\n
+A collection of language tools and a Language Server Protocol (LSP) implementation for Postgres, focusing on developer experience and reliable SQL tooling.\n
 """
 # template for the changelog body
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## {{ version | trim_start_matches(pat="v") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\


### PR DESCRIPTION
- only generates the changelog for the version that is currently released 
- (I think) I fixed the deploy docs on release issue by allowing all tags to push to `github-pages `
![Screenshot 2025-04-15 at 08 37 23](https://github.com/user-attachments/assets/596f1a5a-1afd-4e68-860f-cea3bb055718)
- makes the template a bit nicer. example from the latest release:


# Postgres Language Server

A collection of language tools and a Language Server Protocol (LSP) implementation for Postgres, focusing on developer experience and reliable SQL tooling.

## 0.4.0

### 🚀 Features

- Annotations (#331)
- Request autocompletion without typing a letter (#310)

### 🐛 Bug Fixes

- Make sure range is correct for eof deletions (#311)
- Properly trim statement (#313)
- Downgrade tunners (#318)
- Parse unions (#329)
- C-style comments (#332)

### 🚜 Refactor

- Parser (#322)
- Simplify parser ? (#330)

### 📚 Documentation

- Add zed installation instructions (#315)

