### PR TITLE
fix: dont point to 404 in config schema

### DIFF
--- a/crates/pgt_workspace/src/configuration.rs
+++ b/crates/pgt_workspace/src/configuration.rs
@@ -175,6 +175,7 @@ pub fn create_config(
     if fs.open_with_options(node_schema_path, options).is_ok() {
         configuration.schema = node_schema_path.to_str().map(String::from);
     } else if VERSION == "0.0.0" {
+    // VERSION is 0.0.0 if it has not been explicitly set (e.g local dev, as fallback) 
         configuration.schema = Some("https://pgtools.dev/schemas/latest/schema.json".to_string());
     } else {
         configuration.schema = Some(format!("https://pgtools.dev/schemas/{VERSION}/schema.json"));

--- a/crates/pgt_workspace/src/configuration.rs
+++ b/crates/pgt_workspace/src/configuration.rs
@@ -170,12 +170,14 @@ pub fn create_config(
     })?;
 
     // we now check if postgrestools is installed inside `node_modules` and if so, we use the schema from there
-    let schema_path = Path::new("./node_modules/@postgrestools/postgrestools/schema.json");
+    let node_schema_path = Path::new("./node_modules/@postgrestools/postgrestools/schema.json");
     let options = OpenOptions::default().read(true);
-    if fs.open_with_options(schema_path, options).is_ok() {
-        configuration.schema = schema_path.to_str().map(String::from);
-    } else {
+    if fs.open_with_options(node_schema_path, options).is_ok() {
+        configuration.schema = node_schema_path.to_str().map(String::from);
+    } else if VERSION == "0.0.0" {
         configuration.schema = Some("https://pgtools.dev/schemas/latest/schema.json".to_string());
+    } else {
+        configuration.schema = Some(format!("https://pgtools.dev/schemas/{VERSION}/schema.json"));
     }
 
     let contents = serde_json::to_string_pretty(&configuration)

--- a/crates/pgt_workspace/src/configuration.rs
+++ b/crates/pgt_workspace/src/configuration.rs
@@ -170,14 +170,12 @@ pub fn create_config(
     })?;
 
     // we now check if postgrestools is installed inside `node_modules` and if so, we use the schema from there
-    if VERSION == "0.0.0" {
-        let schema_path = Path::new("./node_modules/@postgrestools/postgrestools/schema.json");
-        let options = OpenOptions::default().read(true);
-        if fs.open_with_options(schema_path, options).is_ok() {
-            configuration.schema = schema_path.to_str().map(String::from);
-        }
+    let schema_path = Path::new("./node_modules/@postgrestools/postgrestools/schema.json");
+    let options = OpenOptions::default().read(true);
+    if fs.open_with_options(schema_path, options).is_ok() {
+        configuration.schema = schema_path.to_str().map(String::from);
     } else {
-        configuration.schema = Some(format!("https://pgtools.dev/schemas/{VERSION}/schema.json"));
+        configuration.schema = Some("https://pgtools.dev/schemas/latest/schema.json".to_string());
     }
 
     let contents = serde_json::to_string_pretty(&configuration)

--- a/crates/pgt_workspace/src/configuration.rs
+++ b/crates/pgt_workspace/src/configuration.rs
@@ -175,7 +175,7 @@ pub fn create_config(
     if fs.open_with_options(node_schema_path, options).is_ok() {
         configuration.schema = node_schema_path.to_str().map(String::from);
     } else if VERSION == "0.0.0" {
-    // VERSION is 0.0.0 if it has not been explicitly set (e.g local dev, as fallback) 
+        // VERSION is 0.0.0 if it has not been explicitly set (e.g local dev, as fallback)
         configuration.schema = Some("https://pgtools.dev/schemas/latest/schema.json".to_string());
     } else {
         configuration.schema = Some(format!("https://pgtools.dev/schemas/{VERSION}/schema.json"));


### PR DESCRIPTION
fixes #319 until we have versioned docs setup by

- preferring node_modules schema if available
- uses `latest` if the CLI does not have a version set (`0.0.0`)
- uses `VERSION` if a version is set