### PR TITLE
fix: properly parse when there is no affected

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Ensure tag matches
-        if: ${{ steps.create_changelog.outputs.version }} != ${{ needs.extract_version.outputs.version }}
+        if: steps.create_changelog.outputs.version != needs.extract_version.outputs.version
         run: exit 1
 
       - name: 👇 Download Artifacts


### PR DESCRIPTION
the previous solution was only working if there are no statements. this has the same effect but also works if there are statements in the file.

fixes #343