### PR TITLE
fix: if clause in workflow file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Ensure tag matches
-        if: ${{ steps.create_changelog.outputs.version }} != ${{ needs.extract_version.outputs.version }}
+        if: steps.create_changelog.outputs.version != needs.extract_version.outputs.version
         run: exit 1
 
       - name: 👇 Download Artifacts


### PR DESCRIPTION
this causes ci to fail because it's always true: https://github.com/supabase-community/postgres-language-server/actions/runs/14575132494/job/40879545415?pr=359