### PR TITLE
oK

### DIFF
--- a/crates/pgt_completions/src/builder.rs
+++ b/crates/pgt_completions/src/builder.rs
@@ -50,6 +50,14 @@ impl<'a> CompletionBuilder<'a> {
 
         let should_preselect_first_item = should_preselect_first_item(&items);
 
+        /*
+         * LSP Clients themselves sort the completion items.
+         * They'll use the `sort_text` property if present (or fallback to the `label`).
+         * Since our items are already sorted, we're 'hijacking' the sort_text.
+         * We're simply adding the index of the item, padded by zeroes to the max length.
+         */
+        let max_padding = items.len().to_string().len();
+
         items
             .into_iter()
             .enumerate()
@@ -61,7 +69,9 @@ impl<'a> CompletionBuilder<'a> {
                     kind: item.kind,
                     label: item.label,
                     preselected,
-                    score: item.score.get_score(),
+
+                    // wonderous Rust syntax ftw
+                    sort_text: format!("{:0>padding$}", idx, padding = max_padding),
                 }
             })
             .collect()

--- a/crates/pgt_completions/src/item.rs
+++ b/crates/pgt_completions/src/item.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -10,12 +12,26 @@ pub enum CompletionItemKind {
     Schema,
 }
 
+impl Display for CompletionItemKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let txt = match self {
+            CompletionItemKind::Table => "Table",
+            CompletionItemKind::Function => "Function",
+            CompletionItemKind::Column => "Column",
+            CompletionItemKind::Schema => "Schema",
+        };
+
+        write!(f, "{txt}")
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct CompletionItem {
     pub label: String,
-    pub(crate) score: i32,
     pub description: String,
     pub preselected: bool,
     pub kind: CompletionItemKind,
+    /// String used for sorting by LSP clients.
+    pub sort_text: String,
 }

--- a/crates/pgt_lsp/src/handlers/completions.rs
+++ b/crates/pgt_lsp/src/handlers/completions.rs
@@ -32,9 +32,10 @@ pub fn get_completions(
             label: i.label,
             label_details: Some(CompletionItemLabelDetails {
                 description: Some(i.description),
-                detail: None,
+                detail: Some(format!(" {}", i.kind)),
             }),
             preselect: Some(i.preselected),
+            sort_text: Some(i.sort_text),
             kind: Some(to_lsp_types_completion_item_kind(i.kind)),
             ..CompletionItem::default()
         })


### PR DESCRIPTION
LSP Clients sort alphanumerically by label, or if present, by `sort_text`. 
We're hijacking that to maintain the sorting our server defines.