### PR TITLE
fix: sql fn params

### DIFF
--- a/crates/pgt_typecheck/src/typed_identifier.rs
+++ b/crates/pgt_typecheck/src/typed_identifier.rs
@@ -1,0 +1,18 @@
+#[derive(Debug)]
+pub struct TypedIdentifier {
+    pub schema: Option<String>,
+    pub relation: String,
+    pub name: String,
+    pub type_: String,
+}
+
+/// Applies the identifiers to the SQL string by replacing them with their default values.
+pub fn apply_identifiers<'a>(
+    identifiers: Vec<TypedIdentifier>,
+    schema_cache: &'a pgt_schema_cache::SchemaCache,
+    cst: &'a tree_sitter::Node<'a>,
+    sql: &'a str,
+) -> &'a str {
+    // TODO
+    sql
+}

--- a/crates/pgt_workspace/src/workspace/server/document.rs
+++ b/crates/pgt_workspace/src/workspace/server/document.rs
@@ -34,6 +34,13 @@ impl Document {
         }
     }
 
+    pub fn statement_content(&self, id: &StatementId) -> Option<&str> {
+        self.positions
+            .iter()
+            .find(|(statement_id, _)| statement_id == id)
+            .map(|(_, range)| &self.content[*range])
+    }
+
     /// Returns true if there is at least one fatal error in the diagnostics
     ///
     /// A fatal error is a scan error that prevents the document from being used

--- a/crates/pgt_workspace/src/workspace/server/sql_function.rs
+++ b/crates/pgt_workspace/src/workspace/server/sql_function.rs
@@ -6,6 +6,18 @@ use pgt_text_size::TextRange;
 use super::statement_identifier::StatementId;
 
 #[derive(Debug, Clone)]
+pub struct SQLFunctionArgs {
+    pub name: Option<String>,
+    pub type_: (Option<String>, String),
+}
+
+#[derive(Debug, Clone)]
+pub struct SQLFunctionSignature {
+    pub name: (Option<String>, String),
+    pub args: Vec<SQLFunctionArgs>,
+}
+
+#[derive(Debug, Clone)]
 pub struct SQLFunctionBody {
     pub range: TextRange,
     pub body: String,
@@ -13,11 +25,33 @@ pub struct SQLFunctionBody {
 
 pub struct SQLFunctionBodyStore {
     db: DashMap<StatementId, Option<Arc<SQLFunctionBody>>>,
+    sig_db: DashMap<StatementId, Option<Arc<SQLFunctionSignature>>>,
 }
 
 impl SQLFunctionBodyStore {
     pub fn new() -> SQLFunctionBodyStore {
-        SQLFunctionBodyStore { db: DashMap::new() }
+        SQLFunctionBodyStore {
+            db: DashMap::new(),
+            sig_db: DashMap::new(),
+        }
+    }
+
+    pub fn get_function_signature(
+        &self,
+        statement: &StatementId,
+        ast: &pgt_query_ext::NodeEnum,
+    ) -> Option<Arc<SQLFunctionSignature>> {
+        // First check if we already have this statement cached
+        if let Some(existing) = self.sig_db.get(statement).map(|x| x.clone()) {
+            return existing;
+        }
+
+        // If not cached, try to extract it from the AST
+        let fn_sig = get_sql_fn_signature(ast).map(Arc::new);
+
+        // Cache the result and return it
+        self.sig_db.insert(statement.clone(), fn_sig.clone());
+        fn_sig
     }
 
     pub fn get_function_body(
@@ -48,6 +82,48 @@ impl SQLFunctionBodyStore {
     }
 }
 
+/// Extracts SQL function signature from a CreateFunctionStmt node.
+fn get_sql_fn_signature(ast: &pgt_query_ext::NodeEnum) -> Option<SQLFunctionSignature> {
+    let create_fn = match ast {
+        pgt_query_ext::NodeEnum::CreateFunctionStmt(cf) => cf,
+        _ => return None,
+    };
+
+    println!("create_fn: {:?}", create_fn);
+
+    // Extract language from function options
+    let language = find_option_value(create_fn, "language")?;
+
+    // Only process SQL functions
+    if language != "sql" {
+        return None;
+    }
+
+    let fn_name = parse_name(&create_fn.funcname)?;
+
+    // we return None if anything is not expected
+    let mut fn_args = Vec::new();
+    for arg in &create_fn.parameters {
+        if let Some(pgt_query_ext::NodeEnum::FunctionParameter(node)) = &arg.node {
+            let arg_name = (!node.name.is_empty()).then_some(node.name.clone());
+
+            let type_name = parse_name(&node.arg_type.as_ref().unwrap().names)?;
+
+            fn_args.push(SQLFunctionArgs {
+                name: arg_name,
+                type_: type_name,
+            });
+        } else {
+            return None;
+        }
+    }
+
+    Some(SQLFunctionSignature {
+        name: fn_name,
+        args: fn_args,
+    })
+}
+
 /// Extracts SQL function body and its text range from a CreateFunctionStmt node.
 /// Returns None if the function is not an SQL function or if the body can't be found.
 fn get_sql_fn(ast: &pgt_query_ext::NodeEnum, content: &str) -> Option<SQLFunctionBody> {
@@ -55,6 +131,8 @@ fn get_sql_fn(ast: &pgt_query_ext::NodeEnum, content: &str) -> Option<SQLFunctio
         pgt_query_ext::NodeEnum::CreateFunctionStmt(cf) => cf,
         _ => return None,
     };
+
+    println!("create_fn: {:?}", create_fn);
 
     // Extract language from function options
     let language = find_option_value(create_fn, "language")?;
@@ -119,4 +197,20 @@ fn find_option_value(
                 None
             }
         })
+}
+
+fn parse_name(nodes: &Vec<pgt_query_ext::protobuf::Node>) -> Option<(Option<String>, String)> {
+    let names = nodes
+        .iter()
+        .map(|n| match &n.node {
+            Some(pgt_query_ext::NodeEnum::String(s)) => Some(s.sval.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    match names.as_slice() {
+        [Some(schema), Some(name)] => Some((Some(schema.clone()), name.clone())),
+        [Some(name)] => Some((None, name.clone())),
+        _ => None,
+    }
 }

--- a/crates/pgt_workspace/src/workspace/server/statement_identifier.rs
+++ b/crates/pgt_workspace/src/workspace/server/statement_identifier.rs
@@ -57,6 +57,21 @@ impl StatementId {
             StatementId::Child(s) => s.inner,
         }
     }
+
+    pub fn is_root(&self) -> bool {
+        matches!(self, StatementId::Root(_))
+    }
+
+    pub fn is_child(&self) -> bool {
+        matches!(self, StatementId::Child(_))
+    }
+
+    pub fn parent(&self) -> Option<StatementId> {
+        match self {
+            StatementId::Root(_) => None,
+            StatementId::Child(id) => Some(StatementId::Root(id.clone())),
+        }
+    }
 }
 
 /// Helper struct to generate unique statement ids


### PR DESCRIPTION
the idea is to replace the fn params with a default value based on their type:
```sql
create or replace function users.select_no_ref (user_id uuid) returns table (
    first_name text
) language sql security invoker as $$
select
    first_name
FROM 
    users_hidden.users
where 
    id = user_id;
$$;
```

will become 

```sql
create or replace function users.select_no_ref (user_id int4) returns table (
    first_name text
) language sql security invoker as $$
select
    first_name
FROM 
    users_hidden.users
where 
    id = 0;
$$;
```

## Todo
- [ ] pass params to typechecker 
- [ ] implement  `apply_identifiers`



fixes #353 
fixes #352 