### PR TITLE
chore: align ci with local dev

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,8 +33,10 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
+
       - name: Free Disk Space
         uses: ./.github/actions/free-disk-space
+
       - name: Install toolchain
         uses: moonrepo/setup-rust@v1
         with:
@@ -43,15 +45,23 @@ jobs:
           cache-base: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Biome
-        uses: biomejs/setup-biome@v2
-        with:
-          version: "1.9.4"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install JS dependencies
+        run: bun install
+
+      - name: Setup Just
+        uses: extractions/setup-just@v3
+
+      - name: Echo Tool Versions
+        run: |
+          just format-ci-versions
+
       - name: Run format
         run: |
-          cargo fmt --all --check
-          taplo format --check
-          biome format
+          just format-ci
 
   actionlint:
     name: Lint GitHub Actions

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: latest
+          version: "1.9.4"
       - name: Run format
         run: |
           cargo fmt --all --check
@@ -96,17 +96,22 @@ jobs:
       - name: Setup sqlx-cli
         run: cargo install sqlx-cli
 
-      - name: Setup Biome
-        uses: biomejs/setup-biome@v2
-        with:
-          version: latest
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install JS dependencies
+        run: bun install
+
+      - name: Setup Just
+        uses: extractions/setup-just@v3
+
+      - name: Echo Tool Versions
+        run: |
+          just lint-ci-versions
 
       - name: Run Lints
         run: |
-          cargo sqlx prepare --check --workspace
-          cargo clippy --fix
-          cargo run -p rules_check
-          biome lint --write
+          just lint-ci
 
       - name: Check for changes
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage     = "https://supabase.com/"
 keywords     = ["linter", "typechecker", "postgres", "language-server"]
 license      = "MIT"
 repository   = "https://github.com/supabase-community/postgres-language-server"
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 
 [workspace.dependencies]
 # supporting crates unrelated to postgres

--- a/crates/pgt_completions/src/providers/helper.rs
+++ b/crates/pgt_completions/src/providers/helper.rs
@@ -7,9 +7,7 @@ pub(crate) fn get_completion_text_with_schema(
     item_name: &str,
     item_schema_name: &str,
 ) -> Option<CompletionText> {
-    if item_schema_name == "public" {
-        None
-    } else if ctx.schema_name.is_some() {
+    if item_schema_name == "public" || ctx.schema_name.is_some() {
         None
     } else {
         let node = ctx.node_under_cursor.unwrap();

--- a/crates/pgt_completions/src/sanitization.rs
+++ b/crates/pgt_completions/src/sanitization.rs
@@ -219,19 +219,19 @@ mod tests {
             .set_language(tree_sitter_sql::language())
             .expect("Error loading sql language");
 
-        let mut tree = parser.parse(input, None).unwrap();
+        let tree = parser.parse(input, None).unwrap();
 
         // select | from users; <-- just right, one space after select token, one space before from
-        assert!(cursor_inbetween_nodes(&mut tree, TextSize::new(7)));
+        assert!(cursor_inbetween_nodes(&tree, TextSize::new(7)));
 
         // select|  from users; <-- still on select token
-        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(6)));
+        assert!(!cursor_inbetween_nodes(&tree, TextSize::new(6)));
 
         // select  |from users; <-- already on from token
-        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(8)));
+        assert!(!cursor_inbetween_nodes(&tree, TextSize::new(8)));
 
         // select from users;|
-        assert!(!cursor_inbetween_nodes(&mut tree, TextSize::new(19)));
+        assert!(!cursor_inbetween_nodes(&tree, TextSize::new(19)));
     }
 
     #[test]
@@ -243,29 +243,29 @@ mod tests {
             .set_language(tree_sitter_sql::language())
             .expect("Error loading sql language");
 
-        let mut tree = parser.parse(input, None).unwrap();
+        let tree = parser.parse(input, None).unwrap();
 
         // select * from| <-- still on previous token
         assert!(!cursor_prepared_to_write_token_after_last_node(
-            &mut tree,
+            &tree,
             TextSize::new(13)
         ));
 
         // select * from  | <-- too far off, two spaces afterward
         assert!(!cursor_prepared_to_write_token_after_last_node(
-            &mut tree,
+            &tree,
             TextSize::new(15)
         ));
 
         // select * |from  <-- it's within
         assert!(!cursor_prepared_to_write_token_after_last_node(
-            &mut tree,
+            &tree,
             TextSize::new(9)
         ));
 
         // select * from | <-- just right
         assert!(cursor_prepared_to_write_token_after_last_node(
-            &mut tree,
+            &tree,
             TextSize::new(14)
         ));
     }
@@ -295,26 +295,26 @@ mod tests {
             .set_language(tree_sitter_sql::language())
             .expect("Error loading sql language");
 
-        let mut tree = parser.parse(input, None).unwrap();
+        let tree = parser.parse(input, None).unwrap();
 
         // select * from     ;| <-- it's after the statement
-        assert!(!cursor_before_semicolon(&mut tree, TextSize::new(19)));
+        assert!(!cursor_before_semicolon(&tree, TextSize::new(19)));
 
         // select * from|    ; <-- still touches the from
-        assert!(!cursor_before_semicolon(&mut tree, TextSize::new(13)));
+        assert!(!cursor_before_semicolon(&tree, TextSize::new(13)));
 
         // not okay to be ON the semi.
         // select * from     |;
-        assert!(!cursor_before_semicolon(&mut tree, TextSize::new(18)));
+        assert!(!cursor_before_semicolon(&tree, TextSize::new(18)));
 
         // anything is fine here
         // select * from |   ;
         // select * from  |  ;
         // select * from   | ;
         // select * from    |;
-        assert!(cursor_before_semicolon(&mut tree, TextSize::new(14)));
-        assert!(cursor_before_semicolon(&mut tree, TextSize::new(15)));
-        assert!(cursor_before_semicolon(&mut tree, TextSize::new(16)));
-        assert!(cursor_before_semicolon(&mut tree, TextSize::new(17)));
+        assert!(cursor_before_semicolon(&tree, TextSize::new(14)));
+        assert!(cursor_before_semicolon(&tree, TextSize::new(15)));
+        assert!(cursor_before_semicolon(&tree, TextSize::new(16)));
+        assert!(cursor_before_semicolon(&tree, TextSize::new(17)));
     }
 }

--- a/crates/pgt_completions/src/test_helper.rs
+++ b/crates/pgt_completions/src/test_helper.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use pgt_schema_cache::SchemaCache;
 use pgt_test_utils::test_database::get_new_test_db;
 use sqlx::Executor;
@@ -25,9 +27,9 @@ impl From<&str> for InputQuery {
     }
 }
 
-impl ToString for InputQuery {
-    fn to_string(&self) -> String {
-        self.sql.clone()
+impl Display for InputQuery {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.sql)
     }
 }
 

--- a/crates/pgt_workspace/src/workspace/server/change.rs
+++ b/crates/pgt_workspace/src/workspace/server/change.rs
@@ -1470,7 +1470,7 @@ mod tests {
                 assert_eq!(old_stmt_text, "select * from");
             }
 
-            _ => assert!(false, "Did not yield a modified statement."),
+            _ => unreachable!("Did not yield a modified statement."),
         }
 
         assert_document_integrity(&doc);
@@ -1516,7 +1516,7 @@ mod tests {
                 assert_eq!(old_stmt_text, "select * from");
             }
 
-            _ => assert!(false, "Did not yield a modified statement."),
+            _ => unreachable!("Did not yield a modified statement."),
         }
 
         assert_document_integrity(&doc);
@@ -1559,7 +1559,7 @@ mod tests {
                 assert_eq!(new_stmt_text, "select * from users");
             }
 
-            _ => assert!(false, "Did not yield a modified statement."),
+            _ => unreachable!("Did not yield a modified statement."),
         }
 
         assert_document_integrity(&doc);

--- a/crates/pgt_workspace/src/workspace/server/document.rs
+++ b/crates/pgt_workspace/src/workspace/server/document.rs
@@ -43,7 +43,7 @@ impl Document {
             .any(|d| d.severity() == Severity::Fatal)
     }
 
-    pub fn iter<'a>(&'a self) -> StatementIterator<'a> {
+    pub fn iter(&self) -> StatementIterator<'_> {
         StatementIterator::new(self)
     }
 }

--- a/crates/pgt_workspace/src/workspace/server/parsed_document.rs
+++ b/crates/pgt_workspace/src/workspace/server/parsed_document.rs
@@ -353,7 +353,7 @@ impl<'a> StatementMapper<'a> for GetCompletionsMapper {
 pub struct GetCompletionsFilter {
     pub cursor_position: TextSize,
 }
-impl<'a> StatementFilter<'a> for GetCompletionsFilter {
+impl StatementFilter<'_> for GetCompletionsFilter {
     fn predicate(&self, _id: &StatementId, range: &TextRange, content: &str) -> bool {
         let is_terminated_by_semi = content.chars().last().is_some_and(|c| c == ';');
 
@@ -367,7 +367,7 @@ impl<'a> StatementFilter<'a> for GetCompletionsFilter {
 }
 
 pub struct NoFilter;
-impl<'a> StatementFilter<'a> for NoFilter {
+impl StatementFilter<'_> for NoFilter {
     fn predicate(&self, _id: &StatementId, _range: &TextRange, _content: &str) -> bool {
         true
     }
@@ -383,7 +383,7 @@ impl CursorPositionFilter {
     }
 }
 
-impl<'a> StatementFilter<'a> for CursorPositionFilter {
+impl StatementFilter<'_> for CursorPositionFilter {
     fn predicate(&self, _id: &StatementId, range: &TextRange, _content: &str) -> bool {
         range.contains(self.pos)
     }
@@ -399,7 +399,7 @@ impl IdFilter {
     }
 }
 
-impl<'a> StatementFilter<'a> for IdFilter {
+impl StatementFilter<'_> for IdFilter {
     fn predicate(&self, id: &StatementId, _range: &TextRange, _content: &str) -> bool {
         *id == self.id
     }

--- a/justfile
+++ b/justfile
@@ -10,16 +10,15 @@ alias rg := reset-git
 # Installs the tools needed to develop
 install-tools:
 	cargo install cargo-binstall
-	cargo binstall cargo-insta taplo-cli
+	cargo binstall cargo-insta taplo-cli sqlx-cli
 	cargo binstall --git "https://github.com/astral-sh/uv" uv
 	bun install
 
 # Upgrades the tools needed to develop
 upgrade-tools:
 	cargo install cargo-binstall --force
-	cargo binstall cargo-insta taplo-cli --force
+	cargo binstall cargo-insta taplo-cli sqlx-cli --force
 	cargo binstall --git "https://github.com/astral-sh/uv" uv --force
-	bun install
 
 # Generates code generated files for the linter
 gen-lint:
@@ -68,6 +67,20 @@ lint:
   bun biome lint
 
 lint-fix:
+  cargo clippy --fix
+  cargo run -p rules_check
+  bun biome lint --write
+
+lint-ci-versions:
+  rustc --version
+  rustup --version
+  cargo --version
+  cargo sqlx --version
+  cargo clippy --version
+  echo "Biome $(bun biome --version)"
+
+lint-ci:
+  cargo sqlx prepare --check --workspace
   cargo clippy --fix
   cargo run -p rules_check
   bun biome lint --write

--- a/justfile
+++ b/justfile
@@ -40,6 +40,16 @@ format:
 	taplo format
 	bun biome format --write
 
+format-ci:
+	cargo fmt --all --check
+	taplo format --check
+	bun biome format
+
+format-ci-versions:
+	cargo --version
+	taplo --version
+	echo "Biome $(bun biome --version)"
+
 [unix]
 _touch file:
   touch {{file}}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,3 @@
 [toolchain]
-# The default profile includes rustc, rust-std, cargo, rust-docs, and clippy.
-# https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-# For some reason, rustfmt is not included in the default profile. Add it here.
-components = ["rustfmt"]
-channel = "nightly"
+channel = "1.86.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-# The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
+# The default profile includes rustc, rust-std, cargo, rust-docs, and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
 # For some reason, rustfmt is not included in the default profile. Add it here.


### PR DESCRIPTION
- pin the rust toolchain to the version we use for the workspace
- reuse `just` commands in CI
- add steps where we print the versions of the tools used in CI
- install `sqlx-cli` with `just install-tools` and `just upgrade-tools` 
- remove `bun install` from `just upgrade-tools` 
- fixed all issues from clippy

the `rust-toolchain.toml` file was weird – it complained for the longest time that `cargo fmt` wasn't available with the 1.86.0 version, but now it just works. Seems to be just buggy sometimes