### PR TITLE
fix?(splitter): allow newlines after commas

### DIFF
--- a/crates/pgt_completions/src/builder.rs
+++ b/crates/pgt_completions/src/builder.rs
@@ -86,7 +86,7 @@ fn should_preselect_first_item(items: &Vec<PossibleCompletionItem>) -> bool {
     let second = items_iter.next();
 
     first.is_some_and(|f| match second {
-        Some(s) => (f.score.get_score() - s.score.get_score()) > 10,
+        Some(s) => (f.score.get_score() - s.score.get_score()) > 15,
         None => true,
-    })
+    }) && items.len() >= 10
 }

--- a/crates/pgt_statement_splitter/src/lib.rs
+++ b/crates/pgt_statement_splitter/src/lib.rs
@@ -333,4 +333,21 @@ values ('insert', new.id, now());",
             "select 3",
         ]);
     }
+
+    #[test]
+    fn commas_and_newlines() {
+        Tester::from(
+            "
+        select
+            email,
+
+
+        from
+            auth.users;
+        ",
+        )
+        .expect_statements(vec![
+            "select\n            email,\n\n\n        from\n            auth.users;",
+        ]);
+    }
 }

--- a/crates/pgt_statement_splitter/src/parser/common.rs
+++ b/crates/pgt_statement_splitter/src/parser/common.rs
@@ -138,10 +138,20 @@ pub(crate) fn unknown(p: &mut Parser, exclude: &[SyntaxKind]) {
                 break;
             }
             Token {
-                kind: SyntaxKind::Newline | SyntaxKind::Eof,
+                kind: SyntaxKind::Eof,
                 ..
             } => {
                 break;
+            }
+            Token {
+                kind: SyntaxKind::Newline,
+                ..
+            } => {
+                if p.look_back().is_some_and(|t| t.kind == SyntaxKind::Ascii44) {
+                    p.advance();
+                } else {
+                    break;
+                }
             }
             Token {
                 kind: SyntaxKind::Case,


### PR DESCRIPTION
looks like we can assume that it's always a statement if there's a comma before the newlines? 

```sql
select
            email,



        from
            auth.users;
```

Note that this doesn't fix [this one](https://github.com/supabase-community/postgres-language-server/issues/372) – it's apparently not a splitter-problem, the file is correclty parsed as a single statement