### PR TITLE
feat(completions): respect table aliases, complete in JOINs

### DIFF
--- a/crates/pgt_completions/src/context.rs
+++ b/crates/pgt_completions/src/context.rs
@@ -160,14 +160,8 @@ impl<'a> CompletionContext<'a> {
             is_in_error_node: false,
         };
 
-        println!("text: {}", ctx.text);
-
         ctx.gather_tree_context();
         ctx.gather_info_from_ts_queries();
-
-        println!("sql: {}", ctx.text);
-        println!("wrapping_clause_type: {:?}", ctx.wrapping_clause_type);
-        println!("wrappping_node_kind: {:?}", ctx.wrapping_node_kind);
 
         ctx
     }

--- a/crates/pgt_completions/src/providers/helper.rs
+++ b/crates/pgt_completions/src/providers/helper.rs
@@ -7,7 +7,7 @@ pub(crate) fn get_completion_text_with_schema(
     item_name: &str,
     item_schema_name: &str,
 ) -> Option<CompletionText> {
-    if item_schema_name == "public" || ctx.schema_name.is_some() {
+    if item_schema_name == "public" || ctx.schema_or_alias_name.is_some() {
         None
     } else {
         let node = ctx.node_under_cursor.unwrap();

--- a/crates/pgt_completions/src/providers/schemas.rs
+++ b/crates/pgt_completions/src/providers/schemas.rs
@@ -59,6 +59,8 @@ mod tests {
                     "private".to_string(),
                     CompletionItemKind::Schema,
                 ),
+                // users table still preferred over system schemas
+                CompletionAssertion::LabelAndKind("users".to_string(), CompletionItemKind::Table),
                 CompletionAssertion::LabelAndKind(
                     "information_schema".to_string(),
                     CompletionItemKind::Schema,
@@ -71,7 +73,6 @@ mod tests {
                     "pg_toast".to_string(),
                     CompletionItemKind::Schema,
                 ),
-                CompletionAssertion::LabelAndKind("users".to_string(), CompletionItemKind::Table),
             ],
             setup,
         )

--- a/crates/pgt_completions/src/providers/tables.rs
+++ b/crates/pgt_completions/src/providers/tables.rs
@@ -123,12 +123,12 @@ mod tests {
         "#;
 
         let test_cases = vec![
-            // (format!("select * from u{}", CURSOR_POS), "user_y"), // user_y is preferred alphanumerically
+            (format!("select * from u{}", CURSOR_POS), "user_y"), // user_y is preferred alphanumerically
             (format!("select * from private.u{}", CURSOR_POS), "user_z"),
-            // (
-            //     format!("select * from customer_support.u{}", CURSOR_POS),
-            //     "user_y",
-            // ),
+            (
+                format!("select * from customer_support.u{}", CURSOR_POS),
+                "user_y",
+            ),
         ];
 
         for (query, expected_label) in test_cases {

--- a/crates/pgt_completions/src/relevance/scoring.rs
+++ b/crates/pgt_completions/src/relevance/scoring.rs
@@ -62,7 +62,7 @@ impl CompletionScore<'_> {
         };
 
         let has_mentioned_tables = !ctx.mentioned_relations.is_empty();
-        let has_mentioned_schema = ctx.schema_name.is_some();
+        let has_mentioned_schema = ctx.schema_or_alias_name.is_some();
 
         self.score += match self.data {
             CompletionRelevanceData::Table(_) => match clause_type {
@@ -98,7 +98,7 @@ impl CompletionScore<'_> {
             Some(wn) => wn,
         };
 
-        let has_mentioned_schema = ctx.schema_name.is_some();
+        let has_mentioned_schema = ctx.schema_or_alias_name.is_some();
         let has_node_text = ctx.get_node_under_cursor_content().is_some();
 
         self.score += match self.data {
@@ -135,7 +135,7 @@ impl CompletionScore<'_> {
     }
 
     fn check_matches_schema(&mut self, ctx: &CompletionContext) {
-        let schema_name = match ctx.schema_name.as_ref() {
+        let schema_name = match ctx.schema_or_alias_name.as_ref() {
             None => return,
             Some(n) => n,
         };

--- a/crates/pgt_completions/src/test_helper.rs
+++ b/crates/pgt_completions/src/test_helper.rs
@@ -146,17 +146,45 @@ mod tests {
 pub(crate) enum CompletionAssertion {
     Label(String),
     LabelAndKind(String, CompletionItemKind),
+    LabelNotExists(String),
+    KindNotExists(CompletionItemKind),
 }
 
 impl CompletionAssertion {
-    fn assert_eq(self, item: CompletionItem) {
+    fn assert(&self, item: &CompletionItem) {
         match self {
             CompletionAssertion::Label(label) => {
-                assert_eq!(item.label, label);
+                assert_eq!(
+                    &item.label, label,
+                    "Expected label to be {}, but got {}",
+                    label, &item.label
+                );
             }
             CompletionAssertion::LabelAndKind(label, kind) => {
-                assert_eq!(item.label, label);
-                assert_eq!(item.kind, kind);
+                assert_eq!(
+                    &item.label, label,
+                    "Expected label to be {}, but got {}",
+                    label, &item.label
+                );
+                assert_eq!(
+                    &item.kind, kind,
+                    "Expected kind to be {:?}, but got {:?}",
+                    kind, &item.kind
+                );
+            }
+            CompletionAssertion::LabelNotExists(label) => {
+                assert_ne!(
+                    &item.label, label,
+                    "Expected label {} not to exist, but found it",
+                    label
+                );
+            }
+            CompletionAssertion::KindNotExists(kind) => {
+                assert_ne!(
+                    &item.kind, kind,
+                    "Expected kind {:?} not to exist, but found it",
+                    kind
+                );
             }
         }
     }
@@ -171,11 +199,30 @@ pub(crate) async fn assert_complete_results(
     let params = get_test_params(&tree, &cache, query.into());
     let items = complete(params);
 
-    assertions
+    let (not_existing, existing): (Vec<CompletionAssertion>, Vec<CompletionAssertion>) =
+        assertions.into_iter().partition(|a| match a {
+            CompletionAssertion::LabelNotExists(_) | CompletionAssertion::KindNotExists(_) => true,
+            _ => false,
+        });
+
+    assert!(
+        items.len() >= existing.len(),
+        "Not enough items returned. Expected at least {} items, but got {}",
+        existing.len(),
+        items.len()
+    );
+
+    for item in &items {
+        for assertion in &not_existing {
+            assertion.assert(item);
+        }
+    }
+
+    existing
         .into_iter()
         .zip(items.into_iter())
         .for_each(|(assertion, result)| {
-            assertion.assert_eq(result);
+            assertion.assert(&result);
         });
 }
 

--- a/crates/pgt_completions/src/test_helper.rs
+++ b/crates/pgt_completions/src/test_helper.rs
@@ -202,7 +202,7 @@ pub(crate) async fn assert_complete_results(
     let (not_existing, existing): (Vec<CompletionAssertion>, Vec<CompletionAssertion>) =
         assertions.into_iter().partition(|a| match a {
             CompletionAssertion::LabelNotExists(_) | CompletionAssertion::KindNotExists(_) => true,
-            _ => false,
+            CompletionAssertion::Label(_) | CompletionAssertion::LabelAndKind(_, _) => false,
         });
 
     assert!(


### PR DESCRIPTION
Recognizes table aliases and only suggestings columns matching the aliased table.
Adds support for join clauses.