### PR TITLE
fix: properly handle multiple changes at once

### DIFF
--- a/crates/pgt_workspace/src/workspace.rs
+++ b/crates/pgt_workspace/src/workspace.rs
@@ -4,7 +4,7 @@ pub use self::client::{TransportRequest, WorkspaceClient, WorkspaceTransport};
 use pgt_analyse::RuleCategories;
 use pgt_configuration::{PartialConfiguration, RuleSelector};
 use pgt_fs::PgTPath;
-use pgt_text_size::{TextRange, TextSize};
+use pgt_text_size::TextRange;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/crates/pgt_workspace/src/workspace.rs
+++ b/crates/pgt_workspace/src/workspace.rs
@@ -46,7 +46,7 @@ pub struct ChangeFileParams {
     pub changes: Vec<ChangeParams>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ChangeParams {
     /// The range of the file that changed. If `None`, the whole file changed.

--- a/crates/pgt_workspace/src/workspace.rs
+++ b/crates/pgt_workspace/src/workspace.rs
@@ -4,7 +4,7 @@ pub use self::client::{TransportRequest, WorkspaceClient, WorkspaceTransport};
 use pgt_analyse::RuleCategories;
 use pgt_configuration::{PartialConfiguration, RuleSelector};
 use pgt_fs::PgTPath;
-use pgt_text_size::TextRange;
+use pgt_text_size::{TextRange, TextSize};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -57,6 +57,15 @@ pub struct ChangeParams {
 impl ChangeParams {
     pub fn overwrite(text: String) -> Self {
         Self { range: None, text }
+    }
+
+    pub fn push_back(&self, by: TextSize) -> Self {
+        Self {
+            range: self
+                .range
+                .map(|r| TextRange::new(r.start() + by, r.end() + by)),
+            text: self.text.clone(),
+        }
     }
 }
 

--- a/crates/pgt_workspace/src/workspace.rs
+++ b/crates/pgt_workspace/src/workspace.rs
@@ -46,7 +46,7 @@ pub struct ChangeFileParams {
     pub changes: Vec<ChangeParams>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ChangeParams {
     /// The range of the file that changed. If `None`, the whole file changed.
@@ -57,15 +57,6 @@ pub struct ChangeParams {
 impl ChangeParams {
     pub fn overwrite(text: String) -> Self {
         Self { range: None, text }
-    }
-
-    pub fn push_back(&self, by: TextSize) -> Self {
-        Self {
-            range: self
-                .range
-                .map(|r| TextRange::new(r.start() + by, r.end() + by)),
-            text: self.text.clone(),
-        }
     }
 }
 

--- a/crates/pgt_workspace/src/workspace/server/change.rs
+++ b/crates/pgt_workspace/src/workspace/server/change.rs
@@ -1,9 +1,5 @@
-use biome_deserialize::Text;
 use pgt_text_size::{TextLen, TextRange, TextSize};
-use std::{
-    i64,
-    ops::{Add, Sub},
-};
+use std::ops::{Add, Sub};
 
 use crate::workspace::{ChangeFileParams, ChangeParams};
 


### PR DESCRIPTION
multiple changes at once happen during search and replace operations. 

Right now, we are handling each individually, one after another. this breaks starting at the second change because the range of each change is always related to the original state, not the previous. after fiddling with the `apply_change` method I figured this solution is the easiest. it expects that all changes are ordered properly, but afaik that's reasonable. if not and we receive bug reports, we can simply sort them. 

EDIT: ahh I need to handle the deletions case too! ✅