### PR TITLE
fix(completions): use fuzzy matching for user input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,6 +2576,7 @@ version = "0.0.0"
 dependencies = [
  "async-std",
  "criterion",
+ "fuzzy-matcher",
  "pgt_schema_cache",
  "pgt_test_utils",
  "pgt_text_size",

--- a/crates/pgt_completions/Cargo.toml
+++ b/crates/pgt_completions/Cargo.toml
@@ -17,6 +17,7 @@ async-std = "1.12.0"
 pgt_text_size.workspace = true
 
 
+fuzzy-matcher                    = "0.3.7"
 pgt_schema_cache.workspace       = true
 pgt_treesitter_queries.workspace = true
 schemars                         = { workspace = true, optional = true }

--- a/crates/pgt_completions/src/providers/columns.rs
+++ b/crates/pgt_completions/src/providers/columns.rs
@@ -273,60 +273,50 @@ mod tests {
             id1 serial primary key,
             name1 text,
             address1 text,
-            email1 text
+            email1 text,
+            user_settings jsonb
         );
 
         create table public.users (
             id2 serial primary key,
             name2 text,
             address2 text,
-            email2 text
+            email2 text,
+            settings jsonb
         );
     "#;
 
-        {
-            let test_case = TestCase {
-                message: "",
-                query: format!(r#"select {} from users"#, CURSOR_POS),
-                label: "suggests from table",
-                description: "",
-            };
+        assert_complete_results(
+            format!(r#"select {} from users"#, CURSOR_POS).as_str(),
+            vec![
+                CompletionAssertion::Label("address2".into()),
+                CompletionAssertion::Label("email2".into()),
+                CompletionAssertion::Label("id2".into()),
+                CompletionAssertion::Label("name2".into()),
+            ],
+            setup,
+        )
+        .await;
 
-            let (tree, cache) = get_test_deps(setup, test_case.get_input_query()).await;
-            let params = get_test_params(&tree, &cache, test_case.get_input_query());
-            let results = complete(params);
+        assert_complete_results(
+            format!(r#"select {} from private.users"#, CURSOR_POS).as_str(),
+            vec![
+                CompletionAssertion::Label("address1".into()),
+                CompletionAssertion::Label("email1".into()),
+                CompletionAssertion::Label("id1".into()),
+                CompletionAssertion::Label("name1".into()),
+            ],
+            setup,
+        )
+        .await;
 
-            assert_eq!(
-                results
-                    .into_iter()
-                    .take(4)
-                    .map(|item| item.label)
-                    .collect::<Vec<String>>(),
-                vec!["address2", "email2", "id2", "name2"]
-            );
-        }
-
-        {
-            let test_case = TestCase {
-                message: "",
-                query: format!(r#"select {} from private.users"#, CURSOR_POS),
-                label: "suggests from table",
-                description: "",
-            };
-
-            let (tree, cache) = get_test_deps(setup, test_case.get_input_query()).await;
-            let params = get_test_params(&tree, &cache, test_case.get_input_query());
-            let results = complete(params);
-
-            assert_eq!(
-                results
-                    .into_iter()
-                    .take(4)
-                    .map(|item| item.label)
-                    .collect::<Vec<String>>(),
-                vec!["address1", "email1", "id1", "name1"]
-            );
-        }
+        // asserts fuzzy finding for "settings"
+        assert_complete_results(
+            format!(r#"select sett{} from private.users"#, CURSOR_POS).as_str(),
+            vec![CompletionAssertion::Label("user_settings".into())],
+            setup,
+        )
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
This makes it such that we rank higher the `portfolio_settings` column if we type "sett" – before, it didn't get any boost.