### PR TITLE
fix: release pipeline points at correct schema.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           tag_name: ${{ steps.create_changelog.outputs.version }}
           files: |
             postgrestools_*
-            docs/schemas/latest/schema.json
+            docs/schemas/schema.json
           fail_on_unmatched_files: true
           draft: true
 


### PR DESCRIPTION
[the latest release](https://github.com/supabase-community/postgres-language-server/actions/runs/15604813111/job/43953423124) failed because of faulty path to the `schema.json`. 

The path was changed in [this PR](https://github.com/supabase-community/postgres-language-server/pull/414). 

Is pointing at `docs/schema/schema.json` correct? 