### PR TITLE
feat(linting): customize severity per rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5128,6 +5128,7 @@ dependencies = [
  "bpaf",
  "pgt_analyse",
  "pgt_analyser",
+ "pgt_diagnostics",
  "pgt_workspace",
  "proc-macro2",
  "pulldown-cmark",

--- a/crates/pgt_analyse/src/macros.rs
+++ b/crates/pgt_analyse/src/macros.rs
@@ -24,6 +24,7 @@ macro_rules! declare_lint_rule {
     ( $( #[doc = $doc:literal] )+ $vis:vis $id:ident {
         version: $version:literal,
         name: $name:tt,
+        severity: $severity:expr_2021,
         $( $key:ident: $value:expr_2021, )*
     } ) => {
 
@@ -32,6 +33,7 @@ macro_rules! declare_lint_rule {
             $vis $id {
                 version: $version,
                 name: $name,
+                severity: $severity,
                 $( $key: $value, )*
             }
         );
@@ -53,6 +55,7 @@ macro_rules! declare_rule {
         ( $( #[doc = $doc:literal] )+ $vis:vis $id:ident {
         version: $version:literal,
         name: $name:tt,
+        severity: $severity:expr_2021,
         $( $key:ident: $value:expr_2021, )*
     } ) => {
         $( #[doc = $doc] )*
@@ -61,7 +64,7 @@ macro_rules! declare_rule {
         impl $crate::RuleMeta for $id {
             type Group = super::Group;
             const METADATA: $crate::RuleMetadata =
-                $crate::RuleMetadata::new($version, $name, concat!( $( $doc, "\n", )* )) $( .$key($value) )*;
+                $crate::RuleMetadata::new($version, $name, concat!( $( $doc, "\n", )* ), $severity) $( .$key($value) )*;
         }
     }
 }

--- a/crates/pgt_analyse/src/rule.rs
+++ b/crates/pgt_analyse/src/rule.rs
@@ -3,7 +3,7 @@ use pgt_console::{MarkupBuf, markup};
 use pgt_diagnostics::advice::CodeSuggestionAdvice;
 use pgt_diagnostics::{
     Advices, Category, Diagnostic, DiagnosticTags, Location, LogCategory, MessageAndDescription,
-    Visit,
+    Severity, Visit,
 };
 use pgt_text_size::TextRange;
 use std::cmp::Ordering;
@@ -31,10 +31,17 @@ pub struct RuleMetadata {
     pub recommended: bool,
     /// The source URL of the rule
     pub sources: &'static [RuleSource],
+    /// The default severity of the rule
+    pub severity: Severity,
 }
 
 impl RuleMetadata {
-    pub const fn new(version: &'static str, name: &'static str, docs: &'static str) -> Self {
+    pub const fn new(
+        version: &'static str,
+        name: &'static str,
+        docs: &'static str,
+        severity: Severity,
+    ) -> Self {
         Self {
             deprecated: None,
             version,
@@ -42,6 +49,7 @@ impl RuleMetadata {
             docs,
             sources: &[],
             recommended: false,
+            severity,
         }
     }
 

--- a/crates/pgt_analyser/CONTRIBUTING.md
+++ b/crates/pgt_analyser/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Let's say we want to create a new **lint** rule called `useMyRuleName`, follow t
    just new-lintrule safety useMyRuleName (<severity>)
    ```
 
-   Where severity is optional but can be "hint", "info", "warn", or "error" (default).
+   Where severity is optional but can be "info", "warn", or "error" (default).
 
    The script will generate a bunch of files inside the `pgt_analyser` crate.
    Among the other files, you'll find a file called `use_my_new_rule_name.rs` inside the `pgt_analyser/lib/src/lint/safety` folder. You'll implement your rule in this file.

--- a/crates/pgt_analyser/CONTRIBUTING.md
+++ b/crates/pgt_analyser/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Let's say we want to create a new **lint** rule called `useMyRuleName`, follow t
    just new-lintrule safety useMyRuleName (<severity>)
    ```
 
-   Where severity is optional but can be "hint", "information", "warning", "error" (default) or "fatal".
+   Where severity is optional but can be "hint", "info", "warn", or "error" (default).
 
    The script will generate a bunch of files inside the `pgt_analyser` crate.
    Among the other files, you'll find a file called `use_my_new_rule_name.rs` inside the `pgt_analyser/lib/src/lint/safety` folder. You'll implement your rule in this file.

--- a/crates/pgt_analyser/CONTRIBUTING.md
+++ b/crates/pgt_analyser/CONTRIBUTING.md
@@ -54,8 +54,10 @@ Let's say we want to create a new **lint** rule called `useMyRuleName`, follow t
 1. Run the command
 
    ```shell
-   just new-lintrule safety useMyRuleName
+   just new-lintrule safety useMyRuleName (<severity>)
    ```
+
+   Where severity is optional but can be "hint", "information", "warning", "error" (default) or "fatal".
 
    The script will generate a bunch of files inside the `pgt_analyser` crate.
    Among the other files, you'll find a file called `use_my_new_rule_name.rs` inside the `pgt_analyser/lib/src/lint/safety` folder. You'll implement your rule in this file.
@@ -187,6 +189,7 @@ declare_lint_rule! {
     pub(crate) ExampleRule {
         version: "next",
         name: "myRuleName",
+        severity: Severity::Error,
         recommended: false,
     }
 }
@@ -206,6 +209,7 @@ declare_lint_rule! {
     pub(crate) ExampleRule {
         version: "next",
         name: "myRuleName",
+        severity: Severity::Error,
         recommended: false,
         sources: &[RuleSource::Squawk("ban-drop-column")],
     }
@@ -228,6 +232,7 @@ declare_lint_rule! {
     pub(crate) ExampleRule {
         version: "next",
         name: "myRuleName",
+        severity: Severity::Error,
         recommended: false,
     }
 }
@@ -280,6 +285,7 @@ declare_lint_rule! {
         version: "next",
         name: "banDropColumn",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Squawk("ban-drop-column")],
     }
 }
@@ -351,6 +357,7 @@ declare_lint_rule! {
         version: "next",
         name: "banDropColumn",
         recommended: true,
+        severity: Severity::Error,
         deprecated: true,
         sources: &[RuleSource::Squawk("ban-drop-column")],
     }

--- a/crates/pgt_analyser/Cargo.toml
+++ b/crates/pgt_analyser/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace = true
 version              = "0.0.0"
 
 [dependencies]
-pgt_analyse   = { workspace = true }
-pgt_console   = { workspace = true }
-pgt_query_ext = { workspace = true }
+pgt_analyse     = { workspace = true }
+pgt_console     = { workspace = true }
 pgt_diagnostics = { workspace = true }
-serde         = { workspace = true }
+pgt_query_ext   = { workspace = true }
+serde           = { workspace = true }
 
 [dev-dependencies]
 insta           = { version = "1.42.1" }

--- a/crates/pgt_analyser/Cargo.toml
+++ b/crates/pgt_analyser/Cargo.toml
@@ -15,6 +15,7 @@ version              = "0.0.0"
 pgt_analyse   = { workspace = true }
 pgt_console   = { workspace = true }
 pgt_query_ext = { workspace = true }
+pgt_diagnostics = { workspace = true }
 serde         = { workspace = true }
 
 [dev-dependencies]

--- a/crates/pgt_analyser/src/lint/safety.rs
+++ b/crates/pgt_analyser/src/lint/safety.rs
@@ -3,6 +3,7 @@
 use pgt_analyse::declare_lint_group;
 pub mod adding_required_field;
 pub mod ban_drop_column;
+pub mod ban_drop_database;
 pub mod ban_drop_not_null;
 pub mod ban_drop_table;
-declare_lint_group! { pub Safety { name : "safety" , rules : [self :: adding_required_field :: AddingRequiredField , self :: ban_drop_column :: BanDropColumn , self :: ban_drop_not_null :: BanDropNotNull , self :: ban_drop_table :: BanDropTable ,] } }
+declare_lint_group! { pub Safety { name : "safety" , rules : [self :: adding_required_field :: AddingRequiredField , self :: ban_drop_column :: BanDropColumn , self :: ban_drop_database :: BanDropDatabase , self :: ban_drop_not_null :: BanDropNotNull , self :: ban_drop_table :: BanDropTable ,] } }

--- a/crates/pgt_analyser/src/lint/safety.rs
+++ b/crates/pgt_analyser/src/lint/safety.rs
@@ -6,4 +6,5 @@ pub mod ban_drop_column;
 pub mod ban_drop_database;
 pub mod ban_drop_not_null;
 pub mod ban_drop_table;
-declare_lint_group! { pub Safety { name : "safety" , rules : [self :: adding_required_field :: AddingRequiredField , self :: ban_drop_column :: BanDropColumn , self :: ban_drop_database :: BanDropDatabase , self :: ban_drop_not_null :: BanDropNotNull , self :: ban_drop_table :: BanDropTable ,] } }
+pub mod ban_truncate_cascade;
+declare_lint_group! { pub Safety { name : "safety" , rules : [self :: adding_required_field :: AddingRequiredField , self :: ban_drop_column :: BanDropColumn , self :: ban_drop_database :: BanDropDatabase , self :: ban_drop_not_null :: BanDropNotNull , self :: ban_drop_table :: BanDropTable , self :: ban_truncate_cascade :: BanTruncateCascade ,] } }

--- a/crates/pgt_analyser/src/lint/safety/adding_required_field.rs
+++ b/crates/pgt_analyser/src/lint/safety/adding_required_field.rs
@@ -1,5 +1,6 @@
 use pgt_analyse::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use pgt_console::markup;
+use pgt_diagnostics::Severity;
 
 declare_lint_rule! {
     /// Adding a new column that is NOT NULL and has no default value to an existing table effectively makes it required.
@@ -17,6 +18,7 @@ declare_lint_rule! {
     pub AddingRequiredField {
         version: "next",
         name: "addingRequiredField",
+        severity: Severity::Error,
         recommended: false,
         sources: &[RuleSource::Squawk("adding-required-field")],
     }

--- a/crates/pgt_analyser/src/lint/safety/ban_drop_column.rs
+++ b/crates/pgt_analyser/src/lint/safety/ban_drop_column.rs
@@ -1,5 +1,6 @@
 use pgt_analyse::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use pgt_console::markup;
+use pgt_diagnostics::Severity;
 
 declare_lint_rule! {
     /// Dropping a column may break existing clients.
@@ -19,6 +20,7 @@ declare_lint_rule! {
     pub BanDropColumn {
         version: "next",
         name: "banDropColumn",
+        severity: Severity::Warning,
         recommended: true,
         sources: &[RuleSource::Squawk("ban-drop-column")],
     }

--- a/crates/pgt_analyser/src/lint/safety/ban_drop_database.rs
+++ b/crates/pgt_analyser/src/lint/safety/ban_drop_database.rs
@@ -1,0 +1,41 @@
+use pgt_analyse::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
+use pgt_console::markup;
+use pgt_diagnostics::Severity;
+
+declare_lint_rule! {
+    /// Dropping a database may break existing clients (and everything else, really).
+    ///
+    /// Make sure that you really want to drop it.
+    pub BanDropDatabase {
+        version: "next",
+        name: "banDropDatabase",
+        severity: Severity::Warning,
+        recommended: false,
+        sources: &[RuleSource::Squawk("ban-drop-database")],
+    }
+}
+
+impl Rule for BanDropDatabase {
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Vec<RuleDiagnostic> {
+        let mut diagnostics = vec![];
+
+        if let pgt_query_ext::NodeEnum::DropStmt(stmt) = &ctx.stmt() {
+            if stmt.remove_type() == pgt_query_ext::protobuf::ObjectType::ObjectDatabase {
+                diagnostics.push(
+                    RuleDiagnostic::new(
+                        rule_category!(),
+                        None,
+                        markup! {
+                            "Dropping a database may break existing clients."
+                        },
+                    )
+                    .detail(None, "You probably don't want to drop your database."),
+                );
+            }
+        }
+
+        diagnostics
+    }
+}

--- a/crates/pgt_analyser/src/lint/safety/ban_drop_database.rs
+++ b/crates/pgt_analyser/src/lint/safety/ban_drop_database.rs
@@ -21,7 +21,7 @@ impl Rule for BanDropDatabase {
     fn run(ctx: &RuleContext<Self>) -> Vec<RuleDiagnostic> {
         let mut diagnostics = vec![];
 
-        if let pgt_query_ext::NodeEnum::DropdbStmt(stmt) = &ctx.stmt() {
+        if let pgt_query_ext::NodeEnum::DropdbStmt(_) = &ctx.stmt() {
             diagnostics.push(
                 RuleDiagnostic::new(
                     rule_category!(),

--- a/crates/pgt_analyser/src/lint/safety/ban_drop_database.rs
+++ b/crates/pgt_analyser/src/lint/safety/ban_drop_database.rs
@@ -21,19 +21,17 @@ impl Rule for BanDropDatabase {
     fn run(ctx: &RuleContext<Self>) -> Vec<RuleDiagnostic> {
         let mut diagnostics = vec![];
 
-        if let pgt_query_ext::NodeEnum::DropStmt(stmt) = &ctx.stmt() {
-            if stmt.remove_type() == pgt_query_ext::protobuf::ObjectType::ObjectDatabase {
-                diagnostics.push(
-                    RuleDiagnostic::new(
-                        rule_category!(),
-                        None,
-                        markup! {
-                            "Dropping a database may break existing clients."
-                        },
-                    )
-                    .detail(None, "You probably don't want to drop your database."),
-                );
-            }
+        if let pgt_query_ext::NodeEnum::DropdbStmt(stmt) = &ctx.stmt() {
+            diagnostics.push(
+                RuleDiagnostic::new(
+                    rule_category!(),
+                    None,
+                    markup! {
+                        "Dropping a database may break existing clients."
+                    },
+                )
+                .detail(None, "You probably don't want to drop your database."),
+            );
         }
 
         diagnostics

--- a/crates/pgt_analyser/src/lint/safety/ban_drop_not_null.rs
+++ b/crates/pgt_analyser/src/lint/safety/ban_drop_not_null.rs
@@ -1,5 +1,6 @@
 use pgt_analyse::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use pgt_console::markup;
+use pgt_diagnostics::Severity;
 
 declare_lint_rule! {
     /// Dropping a NOT NULL constraint may break existing clients.
@@ -18,6 +19,7 @@ declare_lint_rule! {
     pub BanDropNotNull {
         version: "next",
         name: "banDropNotNull",
+        severity: Severity::Warning,
         recommended: true,
         sources: &[RuleSource::Squawk("ban-drop-not-null")],
 

--- a/crates/pgt_analyser/src/lint/safety/ban_drop_table.rs
+++ b/crates/pgt_analyser/src/lint/safety/ban_drop_table.rs
@@ -1,5 +1,6 @@
 use pgt_analyse::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use pgt_console::markup;
+use pgt_diagnostics::Severity;
 
 declare_lint_rule! {
     /// Dropping a table may break existing clients.
@@ -18,6 +19,7 @@ declare_lint_rule! {
     pub BanDropTable {
         version: "next",
         name: "banDropTable",
+        severity: Severity::Warning,
         recommended: true,
         sources: &[RuleSource::Squawk("ban-drop-table")],
     }

--- a/crates/pgt_analyser/src/lint/safety/ban_truncate_cascade.rs
+++ b/crates/pgt_analyser/src/lint/safety/ban_truncate_cascade.rs
@@ -1,0 +1,51 @@
+use pgt_analyse::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
+use pgt_console::markup;
+use pgt_diagnostics::Severity;
+use pgt_query_ext::protobuf::DropBehavior;
+
+declare_lint_rule! {
+    /// Using `TRUNCATE`'s `CASCADE` option will truncate any tables that are also foreign-keyed to the specified tables.
+    ///
+    /// So if you had tables with foreign-keys like:
+    ///
+    /// `a <- b <- c`
+    ///
+    /// and ran:
+    ///
+    /// `truncate a cascade;`
+    ///
+    /// You'd end up with a, b, & c all being truncated!
+    ///
+    /// Instead, you can manually specify the tables you want.
+    ///
+    /// `truncate a, b;`
+    pub BanTruncateCascade {
+        version: "next",
+        name: "banTruncateCascade",
+        severity: Severity::Error,
+        recommended: false,
+        sources: &[RuleSource::Squawk("ban-truncate-cascade")],
+    }
+}
+
+impl Rule for BanTruncateCascade {
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Vec<RuleDiagnostic> {
+        let mut diagnostics = Vec::new();
+
+        if let pgt_query_ext::NodeEnum::TruncateStmt(stmt) = &ctx.stmt() {
+            if stmt.behavior() == DropBehavior::DropCascade {
+                diagnostics.push(RuleDiagnostic::new(
+                            rule_category!(),
+                            None,
+                            markup! {
+                                "The `CASCADE` option will also truncate any tables that are foreign-keyed to the specified tables."
+                            },
+                        ).detail(None, "Do not use the `CASCADE` option. Instead, specify manually what you want: `TRUNCATE a, b;`."));
+            }
+        }
+
+        diagnostics
+    }
+}

--- a/crates/pgt_analyser/src/options.rs
+++ b/crates/pgt_analyser/src/options.rs
@@ -10,3 +10,5 @@ pub type BanDropDatabase =
 pub type BanDropNotNull =
     <lint::safety::ban_drop_not_null::BanDropNotNull as pgt_analyse::Rule>::Options;
 pub type BanDropTable = <lint::safety::ban_drop_table::BanDropTable as pgt_analyse::Rule>::Options;
+pub type BanTruncateCascade =
+    <lint::safety::ban_truncate_cascade::BanTruncateCascade as pgt_analyse::Rule>::Options;

--- a/crates/pgt_analyser/src/options.rs
+++ b/crates/pgt_analyser/src/options.rs
@@ -5,6 +5,8 @@ pub type AddingRequiredField =
     <lint::safety::adding_required_field::AddingRequiredField as pgt_analyse::Rule>::Options;
 pub type BanDropColumn =
     <lint::safety::ban_drop_column::BanDropColumn as pgt_analyse::Rule>::Options;
+pub type BanDropDatabase =
+    <lint::safety::ban_drop_database::BanDropDatabase as pgt_analyse::Rule>::Options;
 pub type BanDropNotNull =
     <lint::safety::ban_drop_not_null::BanDropNotNull as pgt_analyse::Rule>::Options;
 pub type BanDropTable = <lint::safety::ban_drop_table::BanDropTable as pgt_analyse::Rule>::Options;

--- a/crates/pgt_analyser/tests/specs/safety/banDropDatabase/basic.sql
+++ b/crates/pgt_analyser/tests/specs/safety/banDropDatabase/basic.sql
@@ -1,2 +1,2 @@
 -- expect_only_lint/safety/banDropDatabase
--- select 1;
+drop database all_users;

--- a/crates/pgt_analyser/tests/specs/safety/banDropDatabase/basic.sql
+++ b/crates/pgt_analyser/tests/specs/safety/banDropDatabase/basic.sql
@@ -1,0 +1,2 @@
+-- expect_only_lint/safety/banDropDatabase
+-- select 1;

--- a/crates/pgt_analyser/tests/specs/safety/banDropDatabase/basic.sql.snap
+++ b/crates/pgt_analyser/tests/specs/safety/banDropDatabase/basic.sql.snap
@@ -7,3 +7,10 @@ expression: snapshot
 -- expect_only_lint/safety/banDropDatabase
 drop database all_users;
 ```
+
+# Diagnostics
+lint/safety/banDropDatabase ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Dropping a database may break existing clients.
+  
+  i You probably don't want to drop your database.

--- a/crates/pgt_analyser/tests/specs/safety/banDropDatabase/basic.sql.snap
+++ b/crates/pgt_analyser/tests/specs/safety/banDropDatabase/basic.sql.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pgt_analyser/tests/rules_tests.rs
+expression: snapshot
+---
+# Input
+```
+-- expect_only_lint/safety/banDropDatabase
+drop database all_users;
+```

--- a/crates/pgt_analyser/tests/specs/safety/banTruncateCascade/basic.sql
+++ b/crates/pgt_analyser/tests/specs/safety/banTruncateCascade/basic.sql
@@ -1,0 +1,2 @@
+-- expect_only_lint/safety/banTruncateCascade
+-- select 1;

--- a/crates/pgt_analyser/tests/specs/safety/banTruncateCascade/basic.sql
+++ b/crates/pgt_analyser/tests/specs/safety/banTruncateCascade/basic.sql
@@ -1,2 +1,2 @@
 -- expect_only_lint/safety/banTruncateCascade
--- select 1;
+truncate a cascade;

--- a/crates/pgt_analyser/tests/specs/safety/banTruncateCascade/basic.sql.snap
+++ b/crates/pgt_analyser/tests/specs/safety/banTruncateCascade/basic.sql.snap
@@ -1,0 +1,16 @@
+---
+source: crates/pgt_analyser/tests/rules_tests.rs
+expression: snapshot
+---
+# Input
+```
+-- expect_only_lint/safety/banTruncateCascade
+truncate a cascade;
+```
+
+# Diagnostics
+lint/safety/banTruncateCascade ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The `CASCADE` option will also truncate any tables that are foreign-keyed to the specified tables.
+  
+  i Do not use the `CASCADE` option. Instead, specify manually what you want: `TRUNCATE a, b;`.

--- a/crates/pgt_configuration/src/analyser/linter/rules.rs
+++ b/crates/pgt_configuration/src/analyser/linter/rules.rs
@@ -155,8 +155,6 @@ impl Safety {
         "banDropNotNull",
         "banDropTable",
     ];
-    const RECOMMENDED_RULES: &'static [&'static str] =
-        &["banDropColumn", "banDropNotNull", "banDropTable"];
     const RECOMMENDED_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
@@ -232,10 +230,6 @@ impl Safety {
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
     pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
         Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
-    }
-    #[doc = r" Checks if, given a rule name, it is marked as recommended"]
-    pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
-        Self::RECOMMENDED_RULES.contains(&rule_name)
     }
     pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
         Self::RECOMMENDED_RULES_AS_FILTERS

--- a/crates/pgt_configuration/src/analyser/linter/rules.rs
+++ b/crates/pgt_configuration/src/analyser/linter/rules.rs
@@ -258,7 +258,7 @@ impl Safety {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn severity(&self, rule_name: &str) -> Severity {
+    pub(crate) fn severity(rule_name: &str) -> Severity {
         match rule_name {
             "addingRequiredField" => Severity::Error,
             "banDropColumn" => Severity::Warning,

--- a/crates/pgt_diagnostics/src/diagnostic.rs
+++ b/crates/pgt_diagnostics/src/diagnostic.rs
@@ -6,6 +6,7 @@ use std::{
     str::FromStr,
 };
 
+use bpaf::Bpaf;
 use enumflags2::{BitFlags, bitflags, make_bitflags};
 use serde::{Deserialize, Serialize};
 
@@ -115,7 +116,7 @@ pub trait Diagnostic: Debug {
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default, Bpaf,
 )]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/crates/pgt_diagnostics_categories/src/categories.rs
+++ b/crates/pgt_diagnostics_categories/src/categories.rs
@@ -18,6 +18,7 @@ define_categories! {
     "lint/safety/banDropDatabase": "https://pgtools.dev/linter/rules/ban-drop-database",
     "lint/safety/banDropNotNull": "https://pglt.dev/linter/rules/ban-drop-not-null",
     "lint/safety/banDropTable": "https://pglt.dev/linter/rules/ban-drop-table",
+    "lint/safety/banTruncateCascade": "https://pgtools.dev/linter/rules/ban-truncate-cascade",
     // end lint rules
     ;
     // General categories

--- a/crates/pgt_diagnostics_categories/src/categories.rs
+++ b/crates/pgt_diagnostics_categories/src/categories.rs
@@ -15,6 +15,7 @@
 define_categories! {
     "lint/safety/addingRequiredField": "https://pglt.dev/linter/rules/adding-required-field",
     "lint/safety/banDropColumn": "https://pglt.dev/linter/rules/ban-drop-column",
+    "lint/safety/banDropDatabase": "https://pgtools.dev/linter/rules/ban-drop-database",
     "lint/safety/banDropNotNull": "https://pglt.dev/linter/rules/ban-drop-not-null",
     "lint/safety/banDropTable": "https://pglt.dev/linter/rules/ban-drop-table",
     // end lint rules

--- a/crates/pgt_workspace/src/settings.rs
+++ b/crates/pgt_workspace/src/settings.rs
@@ -275,12 +275,10 @@ impl Settings {
         &self,
         code: &Category,
     ) -> Option<pgt_diagnostics::Severity> {
-        let rules = self.linter.rules.as_ref();
-        if let Some(rules) = rules {
-            rules.get_severity_from_code(code)
-        } else {
-            None
-        }
+        self.linter
+            .rules
+            .as_ref()
+            .and_then(|r| r.get_severity_from_code(code))
     }
 }
 

--- a/crates/pgt_workspace/src/workspace/server/annotation.rs
+++ b/crates/pgt_workspace/src/workspace/server/annotation.rs
@@ -22,10 +22,10 @@ impl AnnotationStore {
     #[allow(unused)]
     pub fn get_annotations(
         &self,
-        statement: &StatementId,
+        statement_id: &StatementId,
         content: &str,
     ) -> Option<Arc<StatementAnnotations>> {
-        if let Some(existing) = self.db.get(statement).map(|x| x.clone()) {
+        if let Some(existing) = self.db.get(statement_id).map(|x| x.clone()) {
             return existing;
         }
 
@@ -43,7 +43,7 @@ impl AnnotationStore {
             })
         });
 
-        self.db.insert(statement.clone(), None);
+        self.db.insert(statement_id.clone(), None);
         annotations
     }
 

--- a/docs/rules/ban-drop-column.md
+++ b/docs/rules/ban-drop-column.md
@@ -27,7 +27,7 @@ alter table test drop column id;
 ```sh
 code-block.sql lint/safety/banDropColumn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Dropping a column may break existing clients.
+  ! Dropping a column may break existing clients.
   
   i You can leave the column as nullable or delete the column once queries no longer select or modify the column.
   

--- a/docs/rules/ban-drop-not-null.md
+++ b/docs/rules/ban-drop-not-null.md
@@ -27,7 +27,7 @@ alter table users alter column email drop not null;
 ```sh
 code-block.sql lint/safety/banDropNotNull ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Dropping a NOT NULL constraint may break existing clients.
+  ! Dropping a NOT NULL constraint may break existing clients.
   
   i Consider using a marker value that represents NULL. Alternatively, create a new table allowing NULL values, copy the data from the old table, and create a view that filters NULL values.
   

--- a/docs/rules/ban-drop-table.md
+++ b/docs/rules/ban-drop-table.md
@@ -28,7 +28,7 @@ drop table some_table;
 ```sh
 code-block.sql lint/safety/banDropTable ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Dropping a table may break existing clients.
+  ! Dropping a table may break existing clients.
   
   i Update your application code to no longer read or write the table, and only then delete the table. Be sure to create a backup.
   

--- a/justfile
+++ b/justfile
@@ -31,8 +31,8 @@ gen-lint:
   just format
 
 # Creates a new lint rule in the given path, with the given name. Name has to be camel case. Group should be lowercase.
-new-lintrule group rulename:
-  cargo run -p xtask_codegen -- new-lintrule --category=lint --name={{rulename}} --group={{group}}
+new-lintrule group rulename severity="error":
+  cargo run -p xtask_codegen -- new-lintrule --category=lint --name={{rulename}} --group={{group}} --severity={{severity}}
   just gen-lint
 
 # Format Rust, JS and TOML files

--- a/packages/@postgrestools/backend-jsonrpc/src/workspace.ts
+++ b/packages/@postgrestools/backend-jsonrpc/src/workspace.ts
@@ -65,6 +65,7 @@ export interface Advices {
 export type Category =
 	| "lint/safety/addingRequiredField"
 	| "lint/safety/banDropColumn"
+	| "lint/safety/banDropDatabase"
 	| "lint/safety/banDropNotNull"
 	| "lint/safety/banDropTable"
 	| "stdin"
@@ -392,6 +393,10 @@ export interface Safety {
 	 * Dropping a column may break existing clients.
 	 */
 	banDropColumn?: RuleConfiguration_for_Null;
+	/**
+	 * Succinct description of the rule.
+	 */
+	banDropDatabase?: RuleConfiguration_for_Null;
 	/**
 	 * Dropping a NOT NULL constraint may break existing clients.
 	 */

--- a/packages/@postgrestools/backend-jsonrpc/src/workspace.ts
+++ b/packages/@postgrestools/backend-jsonrpc/src/workspace.ts
@@ -68,6 +68,7 @@ export type Category =
 	| "lint/safety/banDropDatabase"
 	| "lint/safety/banDropNotNull"
 	| "lint/safety/banDropTable"
+	| "lint/safety/banTruncateCascade"
 	| "stdin"
 	| "check"
 	| "configuration"
@@ -394,7 +395,7 @@ export interface Safety {
 	 */
 	banDropColumn?: RuleConfiguration_for_Null;
 	/**
-	 * Succinct description of the rule.
+	 * Dropping a database may break existing clients (and everything else, really).
 	 */
 	banDropDatabase?: RuleConfiguration_for_Null;
 	/**
@@ -405,6 +406,10 @@ export interface Safety {
 	 * Dropping a table may break existing clients.
 	 */
 	banDropTable?: RuleConfiguration_for_Null;
+	/**
+	 * Succinct description of the rule.
+	 */
+	banTruncateCascade?: RuleConfiguration_for_Null;
 	/**
 	 * It enables the recommended rules for this group
 	 */

--- a/packages/@postgrestools/backend-jsonrpc/src/workspace.ts
+++ b/packages/@postgrestools/backend-jsonrpc/src/workspace.ts
@@ -217,7 +217,8 @@ export type CompletionItemKind =
 	| "function"
 	| "column"
 	| "schema"
-	| "policy";
+	| "policy"
+	| "role";
 export interface UpdateSettingsParams {
 	configuration: PartialConfiguration;
 	gitignore_matches: string[];

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -15,6 +15,7 @@ bpaf               = { workspace = true, features = ["derive"] }
 pgt_analyse        = { workspace = true }
 pgt_analyser       = { workspace = true }
 pgt_workspace      = { workspace = true, features = ["schema"] }
+pgt_diagnostics    = { workspace = true }
 proc-macro2        = { workspace = true, features = ["span-locations"] }
 pulldown-cmark     = { version = "0.12.2" }
 quote              = "1.0.36"

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -14,8 +14,8 @@ biome_string_case  = { workspace = true }
 bpaf               = { workspace = true, features = ["derive"] }
 pgt_analyse        = { workspace = true }
 pgt_analyser       = { workspace = true }
-pgt_workspace      = { workspace = true, features = ["schema"] }
 pgt_diagnostics    = { workspace = true }
+pgt_workspace      = { workspace = true, features = ["schema"] }
 proc-macro2        = { workspace = true, features = ["span-locations"] }
 pulldown-cmark     = { version = "0.12.2" }
 quote              = "1.0.36"

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -735,7 +735,7 @@ fn generate_group_struct(
                     }
                 }
 
-                pub(crate) fn severity(&self, rule_name: &str) -> Severity {
+                pub(crate) fn severity(rule_name: &str) -> Severity {
                     match rule_name {
                         #( #get_severity_lines ),*,
                         _ => unreachable!()

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -450,7 +450,6 @@ fn generate_group_struct(
     rules: &BTreeMap<&'static str, RuleMetadata>,
     kind: RuleCategory,
 ) -> TokenStream {
-    let mut lines_recommended_rule = Vec::new();
     let mut lines_recommended_rule_as_filter = Vec::new();
     let mut lines_all_rule_as_filter = Vec::new();
     let mut lines_rule = Vec::new();
@@ -519,10 +518,6 @@ fn generate_group_struct(
         if metadata.recommended {
             lines_recommended_rule_as_filter.push(quote! {
                 RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[#rule_position])
-            });
-
-            lines_recommended_rule.push(quote! {
-                #rule
             });
         }
         lines_all_rule_as_filter.push(quote! {
@@ -658,10 +653,6 @@ fn generate_group_struct(
                     #( #lines_rule ),*
                 ];
 
-                const RECOMMENDED_RULES: &'static [&'static str] = &[
-                    #( #lines_recommended_rule ),*
-                ];
-
                 const RECOMMENDED_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
                     #( #lines_recommended_rule_as_filter ),*
                 ];
@@ -703,11 +694,6 @@ fn generate_group_struct(
                 /// Checks if, given a rule name, matches one of the rules contained in this category
                 pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
                     Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
-                }
-
-                /// Checks if, given a rule name, it is marked as recommended
-                pub(crate) fn is_recommended_rule(rule_name: &str) -> bool {
-                     Self::RECOMMENDED_RULES.contains(&rule_name)
                 }
 
                 pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {

--- a/xtask/codegen/src/generate_new_analyser_rule.rs
+++ b/xtask/codegen/src/generate_new_analyser_rule.rs
@@ -33,6 +33,7 @@ fn generate_rule_template(
     context::RuleContext, {macro_name}, Rule, RuleDiagnostic
 }};
 use pgt_console::markup;
+use pgt::diagnostics::Severity;
 
 {macro_name}! {{
     /// Succinct description of the rule.
@@ -58,6 +59,7 @@ use pgt_console::markup;
     pub {rule_name_upper_camel} {{
         version: "next",
         name: "{rule_name_lower_camel}",
+        severity: Severity::Error,
         recommended: false,
     }}
 }}

--- a/xtask/codegen/src/generate_new_analyser_rule.rs
+++ b/xtask/codegen/src/generate_new_analyser_rule.rs
@@ -33,7 +33,7 @@ fn generate_rule_template(
     context::RuleContext, {macro_name}, Rule, RuleDiagnostic
 }};
 use pgt_console::markup;
-use pgt::diagnostics::Severity;
+use pgt_diagnostics::Severity;
 
 {macro_name}! {{
     /// Succinct description of the rule.

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -13,6 +13,7 @@ pub use self::generate_crate::generate_crate;
 pub use self::generate_new_analyser_rule::generate_new_analyser_rule;
 use bpaf::Bpaf;
 use generate_new_analyser_rule::Category;
+use pgt_diagnostics::Severity;
 use std::path::Path;
 use xtask::{glue::fs2, Mode, Result};
 
@@ -84,5 +85,9 @@ pub enum TaskCommand {
         /// Group of the rule
         #[bpaf(long("group"))]
         group: String,
+
+        /// Group of the rule
+        #[bpaf(long("severity"), fallback(Severity::Error))]
+        severity: Severity,
     },
 }

--- a/xtask/codegen/src/main.rs
+++ b/xtask/codegen/src/main.rs
@@ -21,8 +21,9 @@ fn main() -> Result<()> {
             name,
             category,
             group,
+            severity,
         } => {
-            generate_new_analyser_rule(category, &name, &group);
+            generate_new_analyser_rule(category, &name, &group, severity);
         }
         TaskCommand::Configuration => {
             generate_rules_configuration(Overwrite)?;


### PR DESCRIPTION
That was fun, messing with the codegen and macros :)

Introduces a new required `severity` property on lint rules. It's still overwriteable via the `.jsonc` file. 

Also added two new squawk rules to make sure that the process works as expected.