### PR TITLE
feat: add support for named params

### DIFF
--- a/crates/pgt_lexer/src/lexer.rs
+++ b/crates/pgt_lexer/src/lexer.rs
@@ -132,6 +132,18 @@ impl<'a> Lexer<'a> {
                 pgt_tokenizer::TokenKind::Eof => SyntaxKind::EOF,
                 pgt_tokenizer::TokenKind::Backtick => SyntaxKind::BACKTICK,
                 pgt_tokenizer::TokenKind::PositionalParam => SyntaxKind::POSITIONAL_PARAM,
+                pgt_tokenizer::TokenKind::NamedParam { kind } => {
+                    match kind {
+                        pgt_tokenizer::NamedParamKind::ColonIdentifier { terminated: false } => {
+                            err = "Missing trailing \" to terminate the named parameter";
+                        }
+                        pgt_tokenizer::NamedParamKind::ColonString { terminated: false } => {
+                            err = "Missing trailing ' to terminate the named parameter";
+                        }
+                        _ => {}
+                    };
+                    SyntaxKind::POSITIONAL_PARAM
+                }
                 pgt_tokenizer::TokenKind::QuotedIdent { terminated } => {
                     if !terminated {
                         err = "Missing trailing \" to terminate the quoted identifier"

--- a/crates/pgt_lexer/src/lib.rs
+++ b/crates/pgt_lexer/src/lib.rs
@@ -51,6 +51,36 @@ mod tests {
     }
 
     #[test]
+    fn test_lexing_string_params_with_errors() {
+        let input = "SELECT :'unterminated string";
+        let lexed = lex(input);
+
+        // Should have tokens
+        assert!(!lexed.is_empty());
+
+        // Should have an error for unterminated string
+        let errors = lexed.errors();
+        assert!(!errors.is_empty());
+        // Check the error message exists
+        assert!(!errors[0].message.to_string().is_empty());
+    }
+
+    #[test]
+    fn test_lexing_identifier_params_with_errors() {
+        let input = "SELECT :\"unterminated string";
+        let lexed = lex(input);
+
+        // Should have tokens
+        assert!(!lexed.is_empty());
+
+        // Should have an error for unterminated string
+        let errors = lexed.errors();
+        assert!(!errors.is_empty());
+        // Check the error message exists
+        assert!(!errors[0].message.to_string().is_empty());
+    }
+
+    #[test]
     fn test_token_ranges() {
         let input = "SELECT id";
         let lexed = lex(input);

--- a/crates/pgt_lexer_codegen/src/syntax_kind.rs
+++ b/crates/pgt_lexer_codegen/src/syntax_kind.rs
@@ -43,7 +43,7 @@ const PUNCT: &[(&str, &str)] = &[
     ("`", "BACKTICK"),
 ];
 
-const EXTRA: &[&str] = &["POSITIONAL_PARAM", "ERROR", "COMMENT", "EOF"];
+const EXTRA: &[&str] = &["POSITIONAL_PARAM", "NAMED_PARAM", "ERROR", "COMMENT", "EOF"];
 
 const LITERALS: &[&str] = &[
     "BIT_STRING",

--- a/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_at.snap
+++ b/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_at.snap
@@ -1,0 +1,23 @@
+---
+source: crates/pgt_tokenizer/src/lib.rs
+expression: result
+snapshot_kind: text
+---
+[
+    "select" @ Ident,
+    " " @ Space,
+    "1" @ Literal { kind: Int { base: Decimal, empty_int: false } },
+    " " @ Space,
+    "from" @ Ident,
+    " " @ Space,
+    "c" @ Ident,
+    " " @ Space,
+    "where" @ Ident,
+    " " @ Space,
+    "id" @ Ident,
+    " " @ Space,
+    "=" @ Eq,
+    " " @ Space,
+    "@id" @ NamedParam { kind: AtPrefix },
+    ";" @ Semi,
+]

--- a/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_colon_identifier.snap
+++ b/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_colon_identifier.snap
@@ -1,0 +1,23 @@
+---
+source: crates/pgt_tokenizer/src/lib.rs
+expression: result
+snapshot_kind: text
+---
+[
+    "select" @ Ident,
+    " " @ Space,
+    "1" @ Literal { kind: Int { base: Decimal, empty_int: false } },
+    " " @ Space,
+    "from" @ Ident,
+    " " @ Space,
+    "c" @ Ident,
+    " " @ Space,
+    "where" @ Ident,
+    " " @ Space,
+    "id" @ Ident,
+    " " @ Space,
+    "=" @ Eq,
+    " " @ Space,
+    ":\"id\"" @ NamedParam { kind: ColonIdentifier { terminated: true } },
+    ";" @ Semi,
+]

--- a/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_colon_raw.snap
+++ b/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_colon_raw.snap
@@ -1,0 +1,23 @@
+---
+source: crates/pgt_tokenizer/src/lib.rs
+expression: result
+snapshot_kind: text
+---
+[
+    "select" @ Ident,
+    " " @ Space,
+    "1" @ Literal { kind: Int { base: Decimal, empty_int: false } },
+    " " @ Space,
+    "from" @ Ident,
+    " " @ Space,
+    "c" @ Ident,
+    " " @ Space,
+    "where" @ Ident,
+    " " @ Space,
+    "id" @ Ident,
+    " " @ Space,
+    "=" @ Eq,
+    " " @ Space,
+    ":id" @ NamedParam { kind: ColonRaw },
+    ";" @ Semi,
+]

--- a/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_colon_string.snap
+++ b/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_colon_string.snap
@@ -1,0 +1,23 @@
+---
+source: crates/pgt_tokenizer/src/lib.rs
+expression: result
+snapshot_kind: text
+---
+[
+    "select" @ Ident,
+    " " @ Space,
+    "1" @ Literal { kind: Int { base: Decimal, empty_int: false } },
+    " " @ Space,
+    "from" @ Ident,
+    " " @ Space,
+    "c" @ Ident,
+    " " @ Space,
+    "where" @ Ident,
+    " " @ Space,
+    "id" @ Ident,
+    " " @ Space,
+    "=" @ Eq,
+    " " @ Space,
+    ":'id'" @ NamedParam { kind: ColonString { terminated: true } },
+    ";" @ Semi,
+]

--- a/crates/pgt_tokenizer/src/token.rs
+++ b/crates/pgt_tokenizer/src/token.rs
@@ -94,6 +94,12 @@ pub enum TokenKind {
     ///
     /// see: <https://www.postgresql.org/docs/16/sql-expressions.html#SQL-EXPRESSIONS-PARAMETERS-POSITIONAL>
     PositionalParam,
+    /// Named Parameter, e.g., `@name`
+    ///
+    /// This is used in some ORMs and query builders, like sqlc.
+    NamedParam {
+        kind: NamedParamKind,
+    },
     /// Quoted Identifier, e.g., `"update"` in `update "my_table" set "a" = 5;`
     ///
     /// These are case-sensitive, unlike [`TokenKind::Ident`]
@@ -102,6 +108,30 @@ pub enum TokenKind {
     QuotedIdent {
         terminated: bool,
     },
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum NamedParamKind {
+    /// e.g. `@name`
+    ///
+    /// Used in:
+    /// - sqlc: https://docs.sqlc.dev/en/latest/howto/named_parameters.html
+    AtPrefix,
+
+    /// e.g. `:name` (raw substitution)
+    ///
+    /// Used in: psql
+    ColonRaw,
+
+    /// e.g. `:'name'` (quoted string substitution)
+    ///
+    /// Used in: psql
+    ColonString { terminated: bool },
+
+    /// e.g. `:"name"` (quoted identifier substitution)
+    ///
+    /// Used in: psql
+    ColonIdentifier { terminated: bool },
 }
 
 /// Parsed token.


### PR DESCRIPTION
adds support for named parameters in tokenizer + lexer

for now, we support
- `@name` (sqlc)
- `:name`, `:'name'` and `:"name"` (psql)

closes #455
closes #456

