### PR TITLE
fix: syntax error regression

### DIFF
--- a/crates/pgt_workspace/src/workspace/server/document.rs
+++ b/crates/pgt_workspace/src/workspace/server/document.rs
@@ -259,7 +259,7 @@ impl<'a> StatementMapper<'a> for AnalyserDiagnosticsMapper {
                     (Some(node.clone()), None)
                 }
             }
-            Err(diag) => (None, Some(diag.clone())),
+            Err(diag) => (None, Some(diag.clone().span(range))),
         };
 
         (


### PR DESCRIPTION
syntax errors were not shown anymore due to a missing range.

added a test to catch this regression next time.
