### PR TITLE
fix: add support for named param type `$name`

### DIFF
--- a/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_dollar_raw.snap
+++ b/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__named_param_dollar_raw.snap
@@ -1,0 +1,23 @@
+---
+source: crates/pgt_tokenizer/src/lib.rs
+expression: result
+snapshot_kind: text
+---
+[
+    "select" @ Ident,
+    " " @ Space,
+    "1" @ Literal { kind: Int { base: Decimal, empty_int: false } },
+    " " @ Space,
+    "from" @ Ident,
+    " " @ Space,
+    "c" @ Ident,
+    " " @ Space,
+    "where" @ Ident,
+    " " @ Space,
+    "id" @ Ident,
+    " " @ Space,
+    "=" @ Eq,
+    " " @ Space,
+    "$id" @ NamedParam { kind: DollarRaw },
+    ";" @ Semi,
+]

--- a/crates/pgt_tokenizer/src/token.rs
+++ b/crates/pgt_tokenizer/src/token.rs
@@ -132,6 +132,9 @@ pub enum NamedParamKind {
     ///
     /// Used in: psql
     ColonIdentifier { terminated: bool },
+
+    /// e.g. `$name`
+    DollarRaw,
 }
 
 /// Parsed token.

--- a/crates/pgt_workspace/src/workspace/server.rs
+++ b/crates/pgt_workspace/src/workspace/server.rs
@@ -511,8 +511,6 @@ impl Workspace for WorkspaceServer {
                                 .await
                                 .unwrap_or_else(|_| vec![]);
 
-                                println!("{:#?}", plpgsql_check_results);
-
                                 for d in plpgsql_check_results {
                                     let r = d.span.map(|span| span + range.start());
                                     diagnostics.push(


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes #474 

from https://github.com/supabase-community/postgres-language-server/issues/454#issuecomment-3177986456
