### PR TITLE
feat(completions): correctly infer (quoted) schema for tables & functions

### DIFF
--- a/crates/pgt_completions/src/providers/functions.rs
+++ b/crates/pgt_completions/src/providers/functions.rs
@@ -1,10 +1,11 @@
 use pgt_schema_cache::{Function, SchemaCache};
+use pgt_text_size::TextSize;
 use pgt_treesitter::TreesitterContext;
 
 use crate::{
     CompletionItemKind, CompletionText,
     builder::{CompletionBuilder, PossibleCompletionItem},
-    providers::helper::get_range_to_replace,
+    providers::helper::{get_range_to_replace, node_text_surrounded_by_quotes, only_leading_quote},
     relevance::{CompletionRelevanceData, filtering::CompletionFilter, scoring::CompletionScore},
 };
 
@@ -37,7 +38,7 @@ pub fn complete_functions<'a>(
 fn get_completion_text(ctx: &TreesitterContext, func: &Function) -> CompletionText {
     let mut text = with_schema_or_alias(ctx, func.name.as_str(), Some(func.schema.as_str()));
 
-    let range = get_range_to_replace(ctx);
+    let mut range = get_range_to_replace(ctx);
 
     if ctx.is_invocation {
         CompletionText {
@@ -46,6 +47,11 @@ fn get_completion_text(ctx: &TreesitterContext, func: &Function) -> CompletionTe
             is_snippet: false,
         }
     } else {
+        if node_text_surrounded_by_quotes(ctx) && !only_leading_quote(ctx) {
+            text.push('"');
+            range = range.checked_expand_end(1.into()).unwrap_or(range);
+        }
+
         text.push('(');
 
         let num_args = func.args.args.len();
@@ -68,6 +74,7 @@ fn get_completion_text(ctx: &TreesitterContext, func: &Function) -> CompletionTe
 
 #[cfg(test)]
 mod tests {
+    use pgt_text_size::TextRange;
     use sqlx::{Executor, PgPool};
 
     use crate::{
@@ -289,6 +296,70 @@ mod tests {
                     CompletionItemKind::Function,
                 ),
             ],
+            None,
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test(migrator = "pgt_test_utils::MIGRATIONS")]
+    async fn autocompletes_after_schema_in_quotes(pool: PgPool) {
+        let setup = r#"
+          create schema auth;
+
+          create or replace function auth.my_cool_foo()
+          returns trigger
+          language plpgsql
+          security invoker
+          as $$
+          begin
+            raise exception 'dont matter';
+          end;
+          $$;
+        "#;
+
+        pool.execute(setup).await.unwrap();
+
+        assert_complete_results(
+            format!(
+                r#"select "auth".{}"#,
+                QueryWithCursorPosition::cursor_marker()
+            )
+            .as_str(),
+            vec![CompletionAssertion::CompletionTextAndRange(
+                "my_cool_foo()".into(),
+                TextRange::new(14.into(), 14.into()),
+            )],
+            None,
+            &pool,
+        )
+        .await;
+
+        assert_complete_results(
+            format!(
+                r#"select "auth"."{}"#,
+                QueryWithCursorPosition::cursor_marker()
+            )
+            .as_str(),
+            vec![CompletionAssertion::CompletionTextAndRange(
+                r#"my_cool_foo"()"#.into(),
+                TextRange::new(15.into(), 15.into()),
+            )],
+            None,
+            &pool,
+        )
+        .await;
+
+        assert_complete_results(
+            format!(
+                r#"select "auth"."{}""#,
+                QueryWithCursorPosition::cursor_marker()
+            )
+            .as_str(),
+            vec![CompletionAssertion::CompletionTextAndRange(
+                r#"my_cool_foo"()"#.into(),
+                TextRange::new(15.into(), 16.into()),
+            )],
             None,
             &pool,
         )

--- a/crates/pgt_completions/src/providers/functions.rs
+++ b/crates/pgt_completions/src/providers/functions.rs
@@ -1,5 +1,4 @@
 use pgt_schema_cache::{Function, SchemaCache};
-use pgt_text_size::TextSize;
 use pgt_treesitter::TreesitterContext;
 
 use crate::{

--- a/crates/pgt_completions/src/providers/tables.rs
+++ b/crates/pgt_completions/src/providers/tables.rs
@@ -58,6 +58,7 @@ fn get_completion_text(ctx: &TreesitterContext, table: &Table) -> CompletionText
 #[cfg(test)]
 mod tests {
 
+    use pgt_text_size::TextRange;
     use sqlx::{Executor, PgPool};
 
     use crate::{
@@ -599,8 +600,14 @@ mod tests {
             )
             .as_str(),
             vec![
-                CompletionAssertion::LabelAndKind("posts".into(), CompletionItemKind::Table),
-                CompletionAssertion::LabelAndKind("users".into(), CompletionItemKind::Table),
+                CompletionAssertion::CompletionTextAndRange(
+                    "posts".into(),
+                    TextRange::new(21.into(), 21.into()),
+                ),
+                CompletionAssertion::CompletionTextAndRange(
+                    "users".into(),
+                    TextRange::new(21.into(), 21.into()),
+                ),
             ],
             None,
             &pool,
@@ -609,13 +616,40 @@ mod tests {
 
         assert_complete_results(
             format!(
-                r#"select * from "auth".{}"#,
+                r#"select * from "auth"."{}""#,
                 QueryWithCursorPosition::cursor_marker()
             )
             .as_str(),
             vec![
-                CompletionAssertion::LabelAndKind("posts".into(), CompletionItemKind::Table),
-                CompletionAssertion::LabelAndKind("users".into(), CompletionItemKind::Table),
+                CompletionAssertion::CompletionTextAndRange(
+                    "posts".into(),
+                    TextRange::new(22.into(), 22.into()),
+                ),
+                CompletionAssertion::CompletionTextAndRange(
+                    "users".into(),
+                    TextRange::new(22.into(), 22.into()),
+                ),
+            ],
+            None,
+            &pool,
+        )
+        .await;
+
+        assert_complete_results(
+            format!(
+                r#"select * from "auth"."{}"#,
+                QueryWithCursorPosition::cursor_marker()
+            )
+            .as_str(),
+            vec![
+                CompletionAssertion::CompletionTextAndRange(
+                    r#"posts""#.into(),
+                    TextRange::new(22.into(), 22.into()),
+                ),
+                CompletionAssertion::CompletionTextAndRange(
+                    r#"users""#.into(),
+                    TextRange::new(22.into(), 22.into()),
+                ),
             ],
             None,
             &pool,

--- a/crates/pgt_completions/src/relevance/filtering.rs
+++ b/crates/pgt_completions/src/relevance/filtering.rs
@@ -249,13 +249,13 @@ impl CompletionFilter<'_> {
             return Some(());
         }
 
-        let schema_or_alias = ctx.schema_or_alias_name.as_ref().unwrap();
+        let schema_or_alias = ctx.schema_or_alias_name.as_ref().unwrap().replace('"', "");
 
         let matches = match self.data {
-            CompletionRelevanceData::Table(table) => &table.schema == schema_or_alias,
-            CompletionRelevanceData::Function(f) => &f.schema == schema_or_alias,
+            CompletionRelevanceData::Table(table) => table.schema == schema_or_alias,
+            CompletionRelevanceData::Function(f) => f.schema == schema_or_alias,
             CompletionRelevanceData::Column(col) => ctx
-                .get_mentioned_table_for_alias(schema_or_alias)
+                .get_mentioned_table_for_alias(&schema_or_alias)
                 .is_some_and(|t| t == &col.table_name),
 
             // we should never allow schema suggestions if there already was one.

--- a/crates/pgt_completions/src/relevance/scoring.rs
+++ b/crates/pgt_completions/src/relevance/scoring.rs
@@ -184,9 +184,10 @@ impl CompletionScore<'_> {
     }
 
     fn check_matches_schema(&mut self, ctx: &TreesitterContext) {
+        // TODO
         let schema_name = match ctx.schema_or_alias_name.as_ref() {
             None => return,
-            Some(n) => n,
+            Some(n) => n.replace('"', ""),
         };
 
         let data_schema = match self.get_schema_name() {


### PR DESCRIPTION
- `select "auth"."| ;` will now correctly expand to `"auth"."uid"()` 
- `select "auth"."|" ;` as well
-  `select "auth".|` expands to `"auth".uid()` 

also: before, if there were quotes around a schema, we wouldn't find the possible tables/functions. now we do 🥳 