### PR TITLE
fix: context-aware named param conversion

### DIFF
--- a/crates/pgt_lexer/src/lexer.rs
+++ b/crates/pgt_lexer/src/lexer.rs
@@ -143,7 +143,7 @@ impl<'a> Lexer<'a> {
                         }
                         _ => {}
                     };
-                    SyntaxKind::POSITIONAL_PARAM
+                    SyntaxKind::NAMED_PARAM
                 }
                 pgt_tokenizer::TokenKind::QuotedIdent { terminated } => {
                     if !terminated {

--- a/crates/pgt_tokenizer/src/lib.rs
+++ b/crates/pgt_tokenizer/src/lib.rs
@@ -669,6 +669,13 @@ mod tests {
     }
 
     #[test]
+    fn graphile_named_param() {
+        let result =
+            lex("grant usage on schema public, app_public, app_hidden to :DATABASE_VISITOR;");
+        assert_debug_snapshot!(result);
+    }
+
+    #[test]
     fn named_param_dollar_raw() {
         let result = lex("select 1 from c where id = $id;");
         assert_debug_snapshot!(result);

--- a/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__graphile_named_param.snap
+++ b/crates/pgt_tokenizer/src/snapshots/pgt_tokenizer__tests__graphile_named_param.snap
@@ -1,0 +1,27 @@
+---
+source: crates/pgt_tokenizer/src/lib.rs
+expression: result
+snapshot_kind: text
+---
+[
+    "grant" @ Ident,
+    " " @ Space,
+    "usage" @ Ident,
+    " " @ Space,
+    "on" @ Ident,
+    " " @ Space,
+    "schema" @ Ident,
+    " " @ Space,
+    "public" @ Ident,
+    "," @ Comma,
+    " " @ Space,
+    "app_public" @ Ident,
+    "," @ Comma,
+    " " @ Space,
+    "app_hidden" @ Ident,
+    " " @ Space,
+    "to" @ Ident,
+    " " @ Space,
+    ":DATABASE_VISITOR" @ NamedParam { kind: ColonRaw },
+    ";" @ Semi,
+]


### PR DESCRIPTION
we were blindly converting named parameters to positional parameters. but the latter is only valid as a literal, and not as an identifier.

statements like

```sql
grant usage on schema public, app_public, app_hidden to :DB_ROLE;
```

are not valid when converted to

```sql
grant usage on schema public, app_public, app_hidden to $1;
```

i went a bit back and forth on this and decided the easiest way to fix this is to convert to identifiers like `a` if the previous non-trivia token is one of a set list of tokens. We will probably have a bunch of edge cases here but fixing them should be as easy as adding a keyword to the list.

now, we convert to

```sql
grant usage on schema public, app_public, app_hidden to a;
```

closes #510
