### PR TITLE
fix: npm package name checks

### DIFF
--- a/.github/workflows/publish.reusable.yml
+++ b/.github/workflows/publish.reusable.yml
@@ -47,14 +47,12 @@ jobs:
         if: inputs.is-prerelease != 'true'
         run: |
           for package in packages/@postgrestools/*; do
-            package_basename=$(basename "$package")
-            package_name="@postgrestools/$package_basename"
-            package_version="${{ inputs.release-tag }}"
+            version="${{ inputs.release-tag }}"
 
-            if npm view "$package_name@$package_version" version 2>/dev/null; then
-              echo "Package $package_name@$package_version already exists, skipping..."
+            if npm view "$package@$version" version 2>/dev/null; then
+              echo "Package $package@$version already exists, skipping..."
             else
-              echo "Publishing $package_name@$package_version..."
+              echo "Publishing $package@$version..."
               npm publish "$package" --tag latest --access public --provenance
             fi
           done


### PR DESCRIPTION
`npm view` was checking the wrong package names – we need e.g. `@postgrestools/cli-aarch64-apple-darwin`

<img width="587" height="43" alt="Screenshot 2025-09-19 at 09 37 56" src="https://github.com/user-attachments/assets/b51d0ff7-48ca-460f-acbc-bd0f8a7a1b7f" />
