### PR TITLE
fix: do not push expectation errors to EOF

### DIFF
--- a/.sqlx/query-aced4382cedbfc359bb1c1ab71cf2472fa8afc0b24bf02ee1bfdfdbf111acfc8.json
+++ b/.sqlx/query-aced4382cedbfc359bb1c1ab71cf2472fa8afc0b24bf02ee1bfdfdbf111acfc8.json
@@ -67,7 +67,20 @@
     "parameters": {
       "Left": []
     },
-    "nullable": [null, false, false, false, false, false, null, null, null, null, null, null]
+    "nullable": [
+      null,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
   },
   "hash": "aced4382cedbfc359bb1c1ab71cf2472fa8afc0b24bf02ee1bfdfdbf111acfc8"
 }

--- a/crates/pgt_lexer/src/lexed.rs
+++ b/crates/pgt_lexer/src/lexed.rs
@@ -92,7 +92,7 @@ impl Lexed<'_> {
     }
 
     pub(crate) fn text_range(&self, i: usize) -> TextRange {
-        assert!(i < self.len());
+        assert!(i < self.len() - 1);
         let lo = self.start[i];
         let hi = self.start[i + 1];
         TextRange::new(lo.into(), hi.into())

--- a/crates/pgt_statement_splitter/src/lib.rs
+++ b/crates/pgt_statement_splitter/src/lib.rs
@@ -523,7 +523,7 @@ values ('insert', new.id, now());",
     #[test]
     fn does_not_panic_on_eof_expectation() {
         Tester::from("insert").expect_errors(vec![SplitDiagnostic::new(
-            format!("Expected INTO_KW"),
+            "Expected INTO_KW".to_string(),
             TextRange::new(0.into(), 6.into()),
         )]);
     }

--- a/crates/pgt_statement_splitter/src/lib.rs
+++ b/crates/pgt_statement_splitter/src/lib.rs
@@ -519,4 +519,12 @@ values ('insert', new.id, now());",
             "select\n            email,\n\n\n        from\n            auth.users;",
         ]);
     }
+
+    #[test]
+    fn does_not_panic_on_eof_expectation() {
+        Tester::from("insert").expect_errors(vec![SplitDiagnostic::new(
+            format!("Expected INTO_KW"),
+            TextRange::new(0.into(), 6.into()),
+        )]);
+    }
 }

--- a/crates/pgt_statement_splitter/src/splitter.rs
+++ b/crates/pgt_statement_splitter/src/splitter.rs
@@ -168,9 +168,15 @@ impl<'a> Splitter<'a> {
         if self.current() == kind {
             self.advance();
         } else {
+            let token = if self.current() == SyntaxKind::EOF {
+                self.current_pos - 1
+            } else {
+                self.current_pos
+            };
+
             self.errors.push(SplitError {
                 msg: format!("Expected {:#?}", kind),
-                token: self.current_pos,
+                token,
             });
         }
     }


### PR DESCRIPTION
Splitter Context: If we expect a following keyword, but the next token is EOF, we'd push the expectation error onto the EOF token.

That EOF token is the last token in the `kind` vector, so `i == kind.len() - 1`, so `self.start[i+1]` would error:

<img width="518" height="139" alt="Screenshot 2025-09-26 at 11 41 39" src="https://github.com/user-attachments/assets/55eba2c3-99db-4eb7-a472-c1b8d1f9d314" />

<img width="978" height="524" alt="Screenshot 2025-09-26 at 11 38 25" src="https://github.com/user-attachments/assets/82a790dc-6ece-4c1f-beb1-f512dcd70fb7" />

To solve this case, we'll push the expectation error on the last token before EOF.