### PR TITLE
fix(splitter): handle CTE inside CREATE VIEW statements

### DIFF
--- a/crates/pgls_statement_splitter/src/splitter/common.rs
+++ b/crates/pgls_statement_splitter/src/splitter/common.rs
@@ -224,6 +224,9 @@ pub(crate) fn unknown(p: &mut Splitter, exclude: &[SyntaxKind]) -> SplitterResul
                     begin_end(p)?;
                 }
             },
+            // When WITH_KW is excluded (e.g. inside CREATE) and followed by
+            // an identifier or RECURSIVE, it starts a CTE. Parse it as such
+            // so the following DML keyword is not treated as a new statement.
             t if t == SyntaxKind::WITH_KW
                 && exclude.contains(&SyntaxKind::WITH_KW)
                 && matches!(

--- a/crates/pgls_statement_splitter/src/splitter/common.rs
+++ b/crates/pgls_statement_splitter/src/splitter/common.rs
@@ -224,6 +224,15 @@ pub(crate) fn unknown(p: &mut Splitter, exclude: &[SyntaxKind]) -> SplitterResul
                     begin_end(p)?;
                 }
             },
+            t if t == SyntaxKind::WITH_KW
+                && exclude.contains(&SyntaxKind::WITH_KW)
+                && matches!(
+                    p.look_ahead(true),
+                    SyntaxKind::IDENT | SyntaxKind::RECURSIVE_KW
+                ) =>
+            {
+                cte(p)?;
+            }
             t => match at_statement_start(t, exclude) {
                 Some(SyntaxKind::SELECT_KW) => {
                     let prev = p.look_back(true);

--- a/crates/pgls_statement_splitter/tests/data/create_table_with_storage__1.sql
+++ b/crates/pgls_statement_splitter/tests/data/create_table_with_storage__1.sql
@@ -1,0 +1,1 @@
+CREATE TABLE foo (id int) WITH (fillfactor=70);

--- a/crates/pgls_statement_splitter/tests/data/create_view_with_cte__1.sql
+++ b/crates/pgls_statement_splitter/tests/data/create_view_with_cte__1.sql
@@ -1,0 +1,1 @@
+CREATE OR REPLACE VIEW profile_view AS WITH user_cte AS (SELECT * FROM accounts) SELECT * FROM user_cte;


### PR DESCRIPTION
## Summary
- Fixes the statement splitter incorrectly splitting `CREATE OR REPLACE VIEW ... AS WITH cte AS (...) SELECT ...` into two statements at the `SELECT` keyword
- When `WITH_KW` is excluded (inside a CREATE statement) and followed by an identifier or `RECURSIVE`, the splitter now delegates to the CTE parser so the following DML keyword is consumed as part of the same statement
- Adds test cases for `CREATE VIEW` with CTE and `CREATE TABLE` with storage parameters (`WITH (fillfactor=70)`)

Closes #135

## Test plan
- [x] Added `create_view_with_cte__1.sql` test — verifies the reported bug is fixed
- [x] Added `create_table_with_storage__1.sql` test — verifies non-CTE `WITH` in CREATE is not affected
- [x] All existing splitter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)