### PR TITLE
fix(plpgsql): handle multibyte diagnostic offsets

### DIFF
--- a/crates/pgls_plpgsql_check/src/diagnostics.rs
+++ b/crates/pgls_plpgsql_check/src/diagnostics.rs
@@ -6,36 +6,51 @@ use pgls_text_size::TextRange;
 
 use crate::{PlpgSqlCheckIssue, PlpgSqlCheckResult};
 
-/// Find the first occurrence of target text that is not within string literals
-fn find_text_outside_strings(text: &str, target: &str) -> Option<usize> {
-    let text_lower = text.to_lowercase();
-    let target_lower = target.to_lowercase();
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ByteOffset(usize);
+
+impl ByteOffset {
+    fn get(self) -> usize {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OneBasedCharOffset(usize);
+
+/// Find the first occurrence of target text that is not within string literals.
+///
+/// Returned offsets are byte offsets into `text`, because `TextRange` uses UTF-8
+/// byte offsets internally. Iterate with `char_indices` so every slice starts on
+/// a valid UTF-8 character boundary.
+fn find_text_outside_strings(text: &str, target: &str) -> Option<ByteOffset> {
     let mut in_string = false;
     let mut quote_char = '\0';
-    let bytes = text_lower.as_bytes();
-    let mut i = 0;
+    let bytes = text.as_bytes();
+    let mut chars = text.char_indices().peekable();
 
-    while i < bytes.len() {
-        let ch = bytes[i] as char;
-
+    while let Some((i, ch)) = chars.next() {
         if !in_string {
             // Check if we're starting a string literal
             if ch == '\'' || ch == '"' {
                 in_string = true;
                 quote_char = ch;
-            } else {
-                // Check if we found our target at this position
-                if text_lower[i..].starts_with(&target_lower) {
+            } else if let Some(candidate) = text[i..].get(..target.len()) {
+                // Check if we found our target at this position. The query text
+                // emitted by plpgsql_check is SQL, so ASCII-insensitive matching
+                // is sufficient and avoids lowercasing into a string with
+                // potentially different byte offsets.
+                if candidate == target || candidate.eq_ignore_ascii_case(target) {
                     // Check if this is a complete word (not part of another identifier)
                     let is_word_start =
                         i == 0 || !bytes[i - 1].is_ascii_alphanumeric() && bytes[i - 1] != b'_';
-                    let target_end = i + target_lower.len();
+                    let target_end = i + target.len();
                     let is_word_end = target_end >= bytes.len()
                         || (!bytes[target_end].is_ascii_alphanumeric()
                             && bytes[target_end] != b'_');
 
                     if is_word_start && is_word_end {
-                        return Some(i);
+                        return Some(ByteOffset(i));
                     }
                 }
             }
@@ -43,9 +58,11 @@ fn find_text_outside_strings(text: &str, target: &str) -> Option<usize> {
             // We're inside a string literal
             if ch == quote_char {
                 // Check if it's escaped (look for double quotes/apostrophes)
-                if i + 1 < bytes.len() && bytes[i + 1] as char == quote_char {
+                if let Some((_, next_ch)) = chars.peek()
+                    && *next_ch == quote_char
+                {
                     // Skip the escaped quote
-                    i += 1;
+                    chars.next();
                 } else {
                     // End of string literal
                     in_string = false;
@@ -53,11 +70,22 @@ fn find_text_outside_strings(text: &str, target: &str) -> Option<usize> {
                 }
             }
         }
-
-        i += 1;
     }
 
     None
+}
+
+fn byte_offset_from_one_based_char_offset(
+    text: &str,
+    position: OneBasedCharOffset,
+) -> Option<ByteOffset> {
+    let zero_based_position = position.0.checked_sub(1)?;
+
+    match text.char_indices().nth(zero_based_position) {
+        Some((offset, _)) => Some(ByteOffset(offset)),
+        None if zero_based_position == text.chars().count() => Some(ByteOffset(text.len())),
+        None => None,
+    }
 }
 
 /// A specialized diagnostic for plpgsql_check.
@@ -182,16 +210,21 @@ fn resolve_span(issue: &PlpgSqlCheckIssue, fn_body: &str, offset: usize) -> Opti
     if let Some(q) = &issue.query {
         // first find the query within the fn body *after* stmt_offset, ignoring string literals
         let query_start = find_text_outside_strings(&fn_body[stmt_offset..], &q.text)
-            .map(|pos| pos + stmt_offset);
+            .map(|pos| ByteOffset(pos.get() + stmt_offset));
 
-        // the position is *within* the query text
-        let pos = q
-            .position
-            .parse::<usize>()
-            .expect("Expected query position to be a valid usize")
-            - 1; // -1 because the position is 1-based
+        // The position is *within* the query text. plpgsql_check/Postgres
+        // reports it as a 1-based character position, while TextRange uses
+        // UTF-8 byte offsets.
+        let pos = byte_offset_from_one_based_char_offset(
+            &q.text,
+            OneBasedCharOffset(
+                q.position
+                    .parse::<usize>()
+                    .expect("Expected query position to be a valid usize"),
+            ),
+        )?;
 
-        let start = query_start? + pos;
+        let start = query_start?.get() + pos.get();
 
         // the range of the diagnostics is the token that `pos` is on
         // Find the end of the current token by looking for whitespace or SQL delimiters
@@ -247,4 +280,57 @@ fn resolve_span(issue: &PlpgSqlCheckIssue, fn_body: &str, offset: usize) -> Opti
         ((offset + stmt_offset) as u32).into(),
         ((offset + stmt_offset + end) as u32).into(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Query, Statement};
+
+    fn diagnostic_span_for(fn_body: &str, query_text: &str, position: usize) -> String {
+        let result = PlpgSqlCheckResult {
+            function: "public.f1".to_string(),
+            issues: vec![PlpgSqlCheckIssue {
+                level: "error".to_string(),
+                message: "column does not exist".to_string(),
+                statement: Some(Statement {
+                    line_number: "2".to_string(),
+                    text: "RETURN QUERY".to_string(),
+                }),
+                query: Some(Query {
+                    position: position.to_string(),
+                    text: query_text.to_string(),
+                }),
+                sql_state: Some("42703".to_string()),
+            }],
+        };
+
+        let diagnostics = create_diagnostics_from_check_result(&result, fn_body, 0, None);
+        let span = diagnostics[0].span.expect("expected diagnostic span");
+        fn_body[usize::from(span.start())..usize::from(span.end())].to_string()
+    }
+
+    #[test]
+    fn maps_query_span_when_multibyte_comment_precedes_query() {
+        let query = "SELECT missing_column FROM t";
+        let fn_body = format!("BEGIN\n  RETURN QUERY\n    -- prüfen\n    {query};\nEND");
+
+        assert_eq!(diagnostic_span_for(&fn_body, query, 8), "missing_column");
+    }
+
+    #[test]
+    fn maps_query_position_as_character_offset() {
+        let query = "SELECT 'prüfen', missing_column FROM t";
+        let fn_body = format!("BEGIN\n  RETURN QUERY {query};\nEND");
+        let position = query
+            .chars()
+            .position(|ch| ch == 'm')
+            .expect("query should contain target column")
+            + 1;
+
+        assert_eq!(
+            diagnostic_span_for(&fn_body, query, position),
+            "missing_column"
+        );
+    }
 }


### PR DESCRIPTION
Prevent PL/pgSQL diagnostics from panicking when source text contains UTF-8 multibyte characters before a reported query span.

The diagnostic mapper now keeps internal source ranges as UTF-8 byte offsets while explicitly converting plpgsql_check's one-based character positions at the boundary. Query lookup also iterates on character boundaries instead of byte-by-byte slices, avoiding invalid string indexing inside characters like umlauts.

**Regression Coverage**

Added focused tests for umlauts in comments before a query and in string literals before a reported query position.

Fixes https://github.com/supabase-community/postgres-language-server/issues/735