### PR TITLE
docs(configuration): use correct files.include name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ postgres-language-server check file1.js src/
 
 ### Control files via configuration
 
-The configuration file can be used to refine which files are processed. You can explicitly list the files to be processed using the `files.includes` field. `files.includes` accepts glob patterns such as sql/**/*.sql. Negated patterns starting with `!` can be used to exclude files.
+The configuration file can be used to refine which files are processed. You can explicitly list the files to be processed using the `files.include` field. `files.include` accepts glob patterns such as sql/**/*.sql. Negated patterns starting with `!` can be used to exclude files.
 
 Paths and globs inside the configuration file are resolved relative to the folder the configuration file is in. An exception to this is when a configuration file is extended by another.
 
@@ -86,7 +86,7 @@ Let’s take the following configuration, where we want to include only SQL file
 ```json
 {
   "files": {
-    "includes": ["sql/**/*.sql"]
+    "include": ["sql/**/*.sql"]
   }
 }
 ```


### PR DESCRIPTION
## Summary

Closes #740. The configuration docs at `docs/configuration.md:79,89` referenced `files.includes` (plural) for the include-globs field, but the actual property in `crates/pgls_configuration/src/files.rs:32` is `include` (singular). Users copy-pasting the documented JSON example were getting a silently-ignored key.

## Why this matters

The `FilesConfiguration` struct declares the field as:

```rust
pub include: StringSet,
```

`pgls_workspace/src/workspace/server.rs:212,230` doc comments also reference `files.include`, and the rest of the top-level config schema is singular for ignore-style fields. The docs were the only place spelling the property `includes`. Anyone who configured a workspace following the example would see the parser load the file, accept `includes` as an unknown property (silently dropped), and process every file rather than just the SQL files they intended to scope.

## Changes

- `docs/configuration.md:79` - prose `files.includes` -> `files.include` (two occurrences in the same sentence).
- `docs/configuration.md:89` - JSON snippet key `"includes"` -> `"include"`.

No code change. The example snippet now produces the same result as the underlying `FilesConfiguration` deserializer.

## How to test

```
$ grep -n "files.includes\|\"includes\"" docs/configuration.md
(empty)
$ grep -n "files.include\b\|\"include\"" docs/configuration.md
79:The configuration file can be used to refine which files are processed. You can explicitly list the files to be processed using the `files.include` field. `files.include` accepts glob patterns such as sql/**/*.sql. Negated patterns starting with `!` can be used to exclude files.
89:    "include": ["sql/**/*.sql"]
```

Fixes #740
