### PR TITLE
fix(pretty-print): preserve quoted policy names

### DIFF
--- a/crates/pgls_pretty_print/src/nodes/alter_policy_stmt.rs
+++ b/crates/pgls_pretty_print/src/nodes/alter_policy_stmt.rs
@@ -13,9 +13,7 @@ pub(super) fn emit_alter_policy_stmt(e: &mut EventEmitter, n: &AlterPolicyStmt) 
     e.space();
 
     // Policy name
-    if !n.policy_name.is_empty() {
-        e.token(TokenKind::IDENT(n.policy_name.clone()));
-    }
+    super::emit_identifier_maybe_quoted(e, &n.policy_name);
 
     // Table name
     if let Some(ref table) = n.table {

--- a/crates/pgls_pretty_print/src/nodes/create_policy_stmt.rs
+++ b/crates/pgls_pretty_print/src/nodes/create_policy_stmt.rs
@@ -12,7 +12,7 @@ pub(super) fn emit_create_policy_stmt(e: &mut EventEmitter, n: &CreatePolicyStmt
     e.space();
     e.token(TokenKind::POLICY_KW);
     e.space();
-    e.token(TokenKind::IDENT(n.policy_name.clone()));
+    super::emit_identifier_maybe_quoted(e, &n.policy_name);
 
     e.line(LineType::SoftOrSpace);
     e.token(TokenKind::ON_KW);

--- a/crates/pgls_pretty_print/tests/data/single/alter_policy_quoted_name_0.sql
+++ b/crates/pgls_pretty_print/tests/data/single/alter_policy_quoted_name_0.sql
@@ -1,0 +1,1 @@
+ALTER POLICY "Public can read stats" ON my_table USING (true);

--- a/crates/pgls_pretty_print/tests/data/single/create_policy_quoted_name_0.sql
+++ b/crates/pgls_pretty_print/tests/data/single/create_policy_quoted_name_0.sql
@@ -1,0 +1,1 @@
+CREATE POLICY "Public can read stats" ON my_table FOR SELECT USING (true);

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__alter_policy_quoted_name_0_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__alter_policy_quoted_name_0_100.snap
@@ -1,0 +1,5 @@
+---
+source: crates/pgls_pretty_print/tests/tests.rs
+input_file: crates/pgls_pretty_print/tests/data/single/alter_policy_quoted_name_0.sql
+---
+alter policy "Public can read stats" on my_table using (true);

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__alter_policy_quoted_name_0_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__alter_policy_quoted_name_0_80.snap
@@ -1,0 +1,5 @@
+---
+source: crates/pgls_pretty_print/tests/tests.rs
+input_file: crates/pgls_pretty_print/tests/data/single/alter_policy_quoted_name_0.sql
+---
+alter policy "Public can read stats" on my_table using (true);

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__create_policy_quoted_name_0_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__create_policy_quoted_name_0_100.snap
@@ -1,0 +1,5 @@
+---
+source: crates/pgls_pretty_print/tests/tests.rs
+input_file: crates/pgls_pretty_print/tests/data/single/create_policy_quoted_name_0.sql
+---
+create policy "Public can read stats" on my_table as permissive for select to public using (true);

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__create_policy_quoted_name_0_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__create_policy_quoted_name_0_80.snap
@@ -1,0 +1,10 @@
+---
+source: crates/pgls_pretty_print/tests/tests.rs
+input_file: crates/pgls_pretty_print/tests/data/single/create_policy_quoted_name_0.sql
+---
+create policy "Public can read stats"
+on my_table
+as permissive
+for select
+to public
+using (true);


### PR DESCRIPTION
Preserve quoting for policy names that require quoted identifiers during pretty-printing. Multi-word policy names in `CREATE POLICY` and `ALTER POLICY` now format to valid SQL instead of being emitted as bare identifier tokens.

**Policy identifiers**

The policy statement emitters now use the shared quote-aware identifier helper, matching other policy operations such as drop and rename. Added snapshot coverage for quoted policy names at both configured pretty-printer line widths.

Fixes #748