### PR TITLE
fix(hover): skip unsupported hover nodes

### DIFF
--- a/crates/pgls_hover/src/lib.rs
+++ b/crates/pgls_hover/src/lib.rs
@@ -24,7 +24,7 @@ pub struct OnHoverParams<'a> {
     text = params.stmt_sql,
     position = params.position.to_string()
 ))]
-pub fn on_hover(params: OnHoverParams) -> Vec<String> {
+pub fn on_hover(params: OnHoverParams) -> Option<Vec<String>> {
     let ctx = pgls_treesitter::context::TreesitterContext::new(TreeSitterContextParams {
         position: params.position,
         text: params.stmt_sql,
@@ -123,15 +123,47 @@ pub fn on_hover(params: OnHoverParams) -> Vec<String> {
                     .unwrap_or_default(),
             },
 
-            _ => todo!(),
+            HoveredNode::Policy(_) | HoveredNode::Trigger(_) => return None,
         };
 
-        prioritize_by_context(items, &ctx)
+        let markdown_blocks: Vec<String> = prioritize_by_context(items, &ctx)
             .into_iter()
             .map(|item| format_hover_markdown(&item, params.schema_cache))
             .filter_map(Result::ok)
-            .collect()
+            .collect();
+
+        (!markdown_blocks.is_empty()).then_some(markdown_blocks)
     } else {
-        Default::default()
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hover_over_drop_policy_name_returns_none() {
+        let query =
+            r#"drop policy if exists "Av{}atar images are publicly readable" on storage.objects;"#;
+        let position = query.find("{}").unwrap();
+        let sql = query.replace("{}", "");
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&pgls_treesitter_grammar::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(&sql, None).unwrap();
+        let schema_cache = SchemaCache::default();
+
+        let hover = on_hover(OnHoverParams {
+            position: TextSize::new(position as u32),
+            schema_cache: &schema_cache,
+            stmt_sql: &sql,
+            ast: None,
+            ts_tree: &tree,
+        });
+
+        assert!(hover.is_none());
     }
 }

--- a/crates/pgls_hover/tests/hover_integration_tests.rs
+++ b/crates/pgls_hover/tests/hover_integration_tests.rs
@@ -34,7 +34,8 @@ async fn test_hover_at_cursor(name: &str, query: String, setup: Option<&str>, te
         stmt_sql: &sql,
         ast: ast.as_ref(),
         ts_tree: &tree,
-    });
+    })
+    .unwrap_or_default();
 
     let mut snapshot = String::new();
     snapshot.push_str("# Input\n");

--- a/crates/pgls_lsp/src/handlers/hover.rs
+++ b/crates/pgls_lsp/src/handlers/hover.rs
@@ -7,7 +7,7 @@ use crate::{adapters::get_cursor_position, diagnostics::LspError, session::Sessi
 pub(crate) fn on_hover(
     session: &Session,
     params: lsp_types::HoverParams,
-) -> Result<lsp_types::HoverContents, LspError> {
+) -> Result<Option<lsp_types::HoverContents>, LspError> {
     let url = params.text_document_position_params.text_document.uri;
     let position = params.text_document_position_params.position;
     let path = session.file_path(&url)?;
@@ -19,20 +19,24 @@ pub(crate) fn on_hover(
         Ok(result) => {
             tracing::debug!("Found hover items: {:#?}", result);
 
-            Ok(lsp_types::HoverContents::Array(
-                result
-                    .into_iter()
-                    .map(MarkedString::from_markdown)
-                    .collect(),
-            ))
+            let hover_items: Vec<MarkedString> = result
+                .into_iter()
+                .map(MarkedString::from_markdown)
+                .collect();
+
+            if hover_items.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(lsp_types::HoverContents::Array(hover_items)))
+            }
         }
 
         Err(e) => match e {
             WorkspaceError::DatabaseConnectionError(_) => {
-                Ok(lsp_types::HoverContents::Markup(MarkupContent {
+                Ok(Some(lsp_types::HoverContents::Markup(MarkupContent {
                     kind: lsp_types::MarkupKind::PlainText,
                     value: "Cannot connect to database.".into(),
-                }))
+                })))
             }
             _ => {
                 tracing::error!("Received an error: {:#?}", e);

--- a/crates/pgls_lsp/src/server.rs
+++ b/crates/pgls_lsp/src/server.rs
@@ -270,8 +270,8 @@ impl LanguageServer for LSPServer {
     #[tracing::instrument(level = "trace", skip_all)]
     async fn hover(&self, params: HoverParams) -> LspResult<Option<Hover>> {
         match handlers::hover::on_hover(&self.session, params) {
-            Ok(result) => LspResult::Ok(Some(Hover {
-                contents: result,
+            Ok(result) => LspResult::Ok(result.map(|contents| Hover {
+                contents,
                 range: None,
             })),
             Err(e) => LspResult::Err(into_lsp_error(e)),

--- a/crates/pgls_workspace/src/workspace/server.rs
+++ b/crates/pgls_workspace/src/workspace/server.rs
@@ -1153,7 +1153,8 @@ impl Workspace for WorkspaceServer {
                     ast: maybe_ast.as_ref(),
                     position: position_in_stmt,
                     stmt_sql: stmt_id.content(),
-                });
+                })
+                .unwrap_or_default();
 
                 Ok(OnHoverResult { markdown_blocks })
             }


### PR DESCRIPTION
Avoid crashing hover requests when the cursor is on a parsed node that the hover engine recognizes but does not yet implement, such as policy names in `DROP POLICY` statements. Unsupported hover targets now return no hover result instead of panicking, and empty hover results propagate as `None` through the LSP handler.

**Regression Coverage**

Adds a regression test for hovering over a quoted policy name in `DROP POLICY IF EXISTS`, matching the crash reported in the issue.

Fixes #753