### PR TITLE
Use glibc instead of gnu for libc

### DIFF
--- a/packages/@postgres-language-server/cli/scripts/generate-packages.mjs
+++ b/packages/@postgres-language-server/cli/scripts/generate-packages.mjs
@@ -165,7 +165,7 @@ function copyBinaryToNativePackage(platform, arch, os) {
 
   switch (os) {
     case "linux": {
-      libc = platform.endsWith("musl") ? "musl" : "gnu";
+      libc = platform.endsWith("musl") ? "musl" : "glibc";
       npm_os = "linux";
       break;
     }

--- a/packages/@postgrestools/postgrestools/scripts/generate-packages.mjs
+++ b/packages/@postgrestools/postgrestools/scripts/generate-packages.mjs
@@ -137,7 +137,7 @@ function copyBinaryToNativePackage(platform, arch, os) {
 
   switch (os) {
     case "linux": {
-      libc = platform.endsWith("musl") ? "musl" : "gnu";
+      libc = platform.endsWith("musl") ? "musl" : "glibc";
       npm_os = "linux";
       break;
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #756.

## What is the current behavior?

The `package.json` for platform-specific binary packages incorrectly uses `gnu` instead of `glibc` for the `"libc"` property.

## What is the new behavior?

They now use `libc`.

## Additional context

N/A