### PR TITLE
fix(splitter): do not split EXPLAIN from the explained statement

### DIFF
--- a/crates/pgls_statement_splitter/src/lib.rs
+++ b/crates/pgls_statement_splitter/src/lib.rs
@@ -134,6 +134,39 @@ mod tests {
     }
 
     #[test]
+    fn explain_statements() {
+        let single_statements = vec![
+            "EXPLAIN SELECT 1;",
+            "explain select 1;",
+            "EXPLAIN ANALYZE VERBOSE SELECT * FROM contact;",
+            "EXPLAIN ANALYSE SELECT * FROM contact;",
+            "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) UPDATE contact SET name = 'x';",
+            "EXPLAIN INSERT INTO contact (id) VALUES (1);",
+            "EXPLAIN DELETE FROM contact WHERE id = 1;",
+            "EXPLAIN WITH x AS (SELECT 1) SELECT * FROM x;",
+            "EXPLAIN CREATE TABLE contact_copy AS SELECT * FROM contact;",
+            "EXPLAIN VALUES (1);",
+        ];
+
+        for stmt in single_statements {
+            Tester::from(stmt).expect_statements(vec![stmt]);
+        }
+
+        Tester::from("EXPLAIN SELECT 1; SELECT 2;")
+            .expect_statements(vec!["EXPLAIN SELECT 1;", "SELECT 2;"]);
+
+        Tester::from("explain select 1\nselect 2")
+            .expect_statements(vec!["explain select 1", "select 2"]);
+
+        Tester::from("explain select 1\n\nselect 2")
+            .expect_statements(vec!["explain select 1", "select 2"]);
+
+        // explain is an unreserved keyword and remains usable as an identifier
+        Tester::from("SELECT explain FROM contact;")
+            .expect_statements(vec!["SELECT explain FROM contact;"]);
+    }
+
+    #[test]
     fn begin_commit() {
         Tester::from(
             "BEGIN;

--- a/crates/pgls_statement_splitter/src/splitter/common.rs
+++ b/crates/pgls_statement_splitter/src/splitter/common.rs
@@ -7,7 +7,7 @@ use super::{
     Splitter,
     data::at_statement_start,
     ddl::{alter, create},
-    dml::{cte, delete, insert, select, update},
+    dml::{cte, delete, explain, insert, select, update},
 };
 
 #[derive(Debug)]
@@ -58,6 +58,7 @@ pub(crate) fn statement(p: &mut Splitter) -> SplitterResult {
         SyntaxKind::DELETE_KW => delete(p),
         SyntaxKind::CREATE_KW => create(p),
         SyntaxKind::ALTER_KW => alter(p),
+        SyntaxKind::EXPLAIN_KW => explain(p),
         _ => unknown(p, &[]),
     };
 

--- a/crates/pgls_statement_splitter/src/splitter/dml.rs
+++ b/crates/pgls_statement_splitter/src/splitter/dml.rs
@@ -5,6 +5,7 @@ use crate::splitter::common::SplitterResult;
 use super::{
     Splitter,
     common::{parenthesis, unknown},
+    ddl::create,
 };
 
 pub(crate) fn cte(p: &mut Splitter) -> SplitterResult {
@@ -37,6 +38,38 @@ pub(crate) fn cte(p: &mut Splitter) -> SplitterResult {
         ],
     )?;
     Ok(())
+}
+
+/// `EXPLAIN [ ANALYZE ] [ VERBOSE ] <statement>` and
+/// `EXPLAIN ( option [, ...] ) <statement>`
+///
+/// EXPLAIN is a prefix to the statement it explains, so after consuming the
+/// prefix we delegate to the splitter function of the inner statement instead
+/// of treating its leading keyword as a new statement start.
+pub(crate) fn explain(p: &mut Splitter) -> SplitterResult {
+    p.expect(SyntaxKind::EXPLAIN_KW)?;
+
+    // EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON, ...) <statement>
+    if p.current() == SyntaxKind::L_PAREN {
+        parenthesis(p)?;
+    } else {
+        // legacy EXPLAIN [ANALYZE | ANALYSE] [VERBOSE] <statement>
+        p.eat(SyntaxKind::ANALYZE_KW)?;
+        p.eat(SyntaxKind::ANALYSE_KW)?;
+        p.eat(SyntaxKind::VERBOSE_KW)?;
+    }
+
+    match p.current() {
+        SyntaxKind::WITH_KW => cte(p),
+        SyntaxKind::SELECT_KW => select(p),
+        SyntaxKind::INSERT_KW => insert(p),
+        SyntaxKind::UPDATE_KW => update(p),
+        SyntaxKind::DELETE_KW => delete(p),
+        // EXPLAIN CREATE TABLE AS / CREATE MATERIALIZED VIEW AS
+        SyntaxKind::CREATE_KW => create(p),
+        // MERGE, VALUES, EXECUTE, DECLARE
+        _ => unknown(p, &[]),
+    }
 }
 
 pub(crate) fn select(p: &mut Splitter) -> SplitterResult {

--- a/crates/pgls_statement_splitter/tests/data/explain_statements__5.sql
+++ b/crates/pgls_statement_splitter/tests/data/explain_statements__5.sql
@@ -1,0 +1,9 @@
+explain select 1 from contact;
+
+explain analyze select * from contact where id = 1;
+
+explain (analyze, buffers, format json) update contact set name = 'x' where id = 1;
+
+explain with x as (select 1) select * from x;
+
+select 1;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The statement splitter treats the statement after an `EXPLAIN` prefix as a new statement, so `EXPLAIN SELECT 1` is split into two statements (`EXPLAIN` + `SELECT 1`):

```js
splitStatements('EXPLAIN SELECT 1')
// => [{ sql: 'EXPLAIN' }, { sql: 'SELECT 1' }]
```

Downstream, `lint()` then reports valid SQL as invalid — the bare `EXPLAIN` fragment fails to parse with `Invalid statement: syntax error at end of input` — and consumers that execute the split statements send a broken bare `EXPLAIN` to Postgres. All EXPLAIN forms are affected (`EXPLAIN ANALYZE`, `EXPLAIN (ANALYZE, BUFFERS)`, etc.).

This is the same mis-split class previously fixed for UNION (#321) and GRANT (#417).

## What is the new behavior?

`EXPLAIN` is handled as a statement prefix: a dedicated `explain()` splitter function consumes the prefix — the parenthesized option list or the legacy `[ANALYZE | ANALYSE] [VERBOSE]` modifiers — and then delegates to the splitter function of the explained statement, mirroring how `statement()` dispatches. Covered forms include `EXPLAIN SELECT/INSERT/UPDATE/DELETE`, `EXPLAIN WITH ... SELECT`, `EXPLAIN CREATE TABLE AS`, `EXPLAIN VALUES`, and multi-statement sources (`EXPLAIN SELECT 1; SELECT 2` splits at the semicolon).

`EXPLAIN_KW` is deliberately not added to `STATEMENT_START_TOKENS`: `explain` is an unreserved keyword and remains valid as an identifier mid-statement (e.g. `SELECT explain FROM t`), which a break-on-EXPLAIN rule in `unknown()` would mis-split. A regression test covers this.

## Additional context

Found while integrating `@postgres-language-server/wasm` for SQL editing/execution at ClickHouse, where this surfaced both as lint false positives and as broken EXPLAIN execution.