### PR TITLE
fix(lsp): discard stale diagnostics for outdated document versions

### DIFF
--- a/crates/pgls_lsp/src/session.rs
+++ b/crates/pgls_lsp/src/session.rs
@@ -29,7 +29,7 @@ use tower_lsp::lsp_types::Url;
 use tower_lsp::lsp_types::{self, ClientCapabilities};
 use tower_lsp::lsp_types::{MessageType, Registration};
 use tower_lsp::lsp_types::{Unregistration, WorkspaceFolder};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 pub(crate) struct ClientInformation {
     #[allow(dead_code)]
@@ -265,6 +265,7 @@ impl Session {
     pub(crate) async fn update_diagnostics(&self, url: lsp_types::Url) -> Result<(), LspError> {
         let pgls_path = self.file_path(&url)?;
         let doc = self.document(&url)?;
+        let captured_version = doc.version;
         if self.configuration_status().is_error() && !self.notified_broken_configuration() {
             self.set_notified_broken_configuration();
             self.client
@@ -306,8 +307,19 @@ impl Session {
                 .collect()
         };
 
+        let current_version = match self.document(&url) {
+            Ok(doc) => doc.version,
+            Err(_) => return Ok(()),
+        };
+        if is_stale_diagnostics(captured_version, current_version) {
+            debug!(
+                "discarding stale diagnostics for {url}: computed for version {captured_version}, current is {current_version}"
+            );
+            return Ok(());
+        }
+
         self.client
-            .publish_diagnostics(url, diagnostics, Some(doc.version))
+            .publish_diagnostics(url, diagnostics, Some(captured_version))
             .await;
 
         Ok(())
@@ -604,5 +616,32 @@ impl Session {
             .map_or(PositionEncoding::Wide(WideEncoding::Utf16), |params| {
                 negotiated_encoding(&params.client_capabilities)
             })
+    }
+}
+
+/// Returns `true` when diagnostics computed for `captured_version` no longer
+/// match the document's `current_version` and must therefore be discarded.
+///
+/// Any mismatch is treated as stale, not just a strictly newer version: a
+/// document that is closed and reopened may have its version reset to a lower
+/// number, so an in-flight run captured at a higher version must not publish
+/// over the freshly reopened document.
+fn is_stale_diagnostics(captured_version: i32, current_version: i32) -> bool {
+    captured_version != current_version
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_stale_diagnostics;
+
+    #[test]
+    fn stale_diagnostics_are_detected_by_version() {
+        // A newer version arrived while diagnostics were computed.
+        assert!(is_stale_diagnostics(1, 2));
+        // Same version: the result still matches the live document.
+        assert!(!is_stale_diagnostics(2, 2));
+        // Reopened document reset to a lower version: still stale, the
+        // captured result no longer matches the live document.
+        assert!(is_stale_diagnostics(5, 3));
     }
 }


### PR DESCRIPTION
## Summary

Discard LSP diagnostics that were computed for an outdated document version, so stale results are never published over a newer (or freshly reopened) document.

`Session::update_diagnostics` awaits the DB-backed `pull_file_diagnostics`. During rapid edits to a large SQL file, each `textDocument/didChange` runs this synchronously, and responses for older document versions arrive after newer edits have already been applied. Previously those stale results were still published, causing diagnostics computed against superseded snapshots to overwrite newer ones.

This change captures the document version before computing diagnostics, re-reads the current version after the await point, and skips publishing when the versions no longer match. Any version mismatch is treated as stale (not just a strictly newer version), which also covers the close/reopen case where a client resets the document version to a lower number.

## Why this matters

Refs #744. The issue reports that editing large SQL files triggers a backlog of sequential analysis requests whose stale responses keep getting published after the user stops typing. Discarding results for non-current document versions is one of the fixes the reporter asked for ("Track document version and discard results for non-current versions"), and it removes the visible flicker of stale diagnostics with a minimal, low-risk change. The `Document` struct already carries `version`, so no schema change is needed.

This is a partial fix: debounce, in-flight cancellation tokens, and per-document queue-depth coalescing would reduce the redundant analysis work itself, but they require a dedicated server-side scheduler and are left as a separate, larger change. The version guard is independent and useful on its own.

## Testing

- Added a unit test for the version-comparison decision (`session::tests::stale_diagnostics_are_detected_by_version`), covering: a newer version arriving (stale), the same version (publish), and a reopened document reset to a lower version (stale). This test has no database dependency.
- `cargo check -p pgls_lsp`, `cargo fmt -p pgls_lsp --check`, and `cargo clippy -p pgls_lsp` all pass.
- The existing `pgls_lsp` integration tests are `#[sqlx::test]` and require a live Postgres test database; they were not run as part of this change (no behavioral change to those paths beyond the version guard).
