### PR TITLE
docs: add Helix editor setup instructions to IDE guide

### DIFF
--- a/docs/guides/ide_setup.md
+++ b/docs/guides/ide_setup.md
@@ -68,6 +68,30 @@ If the language server isn't working:
 
 The language client is available through [lsp-mode](https://github.com/emacs-lsp/lsp-mode). For more details, refer to their [manual page](https://emacs-lsp.github.io/lsp-mode/page/lsp-postgres/).
 
+## Helix
+
+Add the language server and SQL grammar to your Helix `languages.toml`:
+
+```toml
+[language-server.postgres-language-server]
+command = "postgres-language-server"
+args = ["lsp-proxy"]
+
+[[language]]
+name = "sql"
+scope = "source.sql"
+injection-regex = "sql"
+file-types = ["sql"]
+comment-token = "--"
+roots = ["postgres-language-server.jsonc"]
+language-servers = ["postgres-language-server"]
+grammar = "sql"
+
+[[grammar]]
+name = "sql"
+source = { git = "https://github.com/DerekStride/tree-sitter-sql", rev = "7b51ecda191d36b92f5a90a8d1bc3faef1c7b8b8" }
+```
+
 ## Cursor
 
 The language server is available on the [Open VSX Registry](https://open-vsx.org/extension/supabase/postgrestools). Install it from the extensions panel in Cursor.


### PR DESCRIPTION
## Summary

Adds a Helix editor section to the IDE setup guide showing how to configure postgres-language-server as a language server in Helix, using the current binary and configuration names.

## Why this matters

The IDE setup guide covered other editors but not Helix, and a working Helix configuration had been posted in the issue thread under the old `postgrestools` branding. This documents a Helix setup that uses the current `postgres-language-server` binary and config names so users can copy it directly. Requested in #471 (contributors welcome; maintainer said happy to accept).

## Testing

Documentation-only change; verified the binary and configuration names against the current repository.

Closes #471
