### PR TITLE
fix(doc): use the db key in the database configuration guide

### DIFF
--- a/docs/guides/configure_database.md
+++ b/docs/guides/configure_database.md
@@ -17,7 +17,7 @@ Configure database connection details in your `postgres-language-server.jsonc` f
 
 ```json
 {
-  "database": {
+  "db": {
     // Database host address (default: "127.0.0.1")
     "host": "localhost",
     // Database port (default: 5432)
@@ -58,7 +58,7 @@ You can control which schemas allow code action statement execution (executing s
 
 ```json
 {
-  "database": {
+  "db": {
     "allowStatementExecutionsAgainst": ["public", "testing"]
   }
 }
@@ -70,7 +70,7 @@ If you prefer to work without a database connection, you can disable all databas
 
 ```json
 {
-  "database": {
+  "db": {
     "disableConnection": true
   }
 }


### PR DESCRIPTION
`docs/guides/configure_database.md` nests the connection settings under a top-level `"database"` key in all three examples. The actual key is `"db"`:

- `crates/pgls_configuration/src/lib.rs:133` — `pub db: DatabaseConfiguration`
- `docs/schema.json` lists `db` among the top-level properties and has no `database` there
- the partial configuration is generated with `serde(deny_unknown_fields)` (`lib.rs:75`), so a file copied from this guide does not parse — the reader gets an error on the one page that exists specifically to explain how to connect to a database

Every other page already uses the correct key, for example `docs/configuration.md:40` and `docs/getting_started.md:42`.

The inner `"database"` key on line 30 is left alone — that one is a real field of `DatabaseConfiguration` and holds the database name.

Documentation only, three lines.