### PR TITLE
chore: upgrade tree-sitter to 0.27

### DIFF
--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -69,13 +69,12 @@ runs:
         export PATH="$(pg_config --bindir):$PATH"
 
         # Install cargo-pgrx (version must match pglinter's pgrx dependency).
-        # pgrx 0.18.0 requires Rust 1.89+, while this project currently builds with 1.88.
-        rustup toolchain install 1.89.0 --profile minimal
-        cargo +1.89.0 install cargo-pgrx --version 0.18.0 --locked
+        rustup toolchain install 1.90.0 --profile minimal
+        cargo +1.90.0 install cargo-pgrx --version 0.18.0 --locked
 
         # Ensure we build the extension for the host architecture (macOS-14 runners are arm64).
         # Release workflow also cross-compiles x86_64, but the local PostgreSQL installation is arm64.
-        HOST_TARGET=$(rustc +1.89.0 -vV | sed -n 's/^host: //p')
+        HOST_TARGET=$(rustc +1.90.0 -vV | sed -n 's/^host: //p')
         echo "Host target: ${HOST_TARGET}"
 
         # Determine postgres version for pgrx init
@@ -83,7 +82,7 @@ runs:
         echo "PostgreSQL version: $PG_VERSION"
 
         # Initialize pgrx for the installed PostgreSQL version
-        cargo +1.89.0 pgrx init --pg${PG_VERSION} $(which pg_config)
+        cargo +1.90.0 pgrx init --pg${PG_VERSION} $(which pg_config)
 
         # Clone and build pglinter (requires v1.1.0+ for get_violations API + rule_messages table)
         cd /tmp
@@ -93,7 +92,7 @@ runs:
         # Install using pgrx
         # Ensure macOS linker allows unresolved PostgreSQL symbols at link time.
         export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-Wl,-undefined,dynamic_lookup"
-        cargo +1.89.0 pgrx install --pg-config $(which pg_config) --release --target "${HOST_TARGET}"
+        cargo +1.90.0 pgrx install --pg-config $(which pg_config) --release --target "${HOST_TARGET}"
 
         # Verify installation
         echo "Extension control files:"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.114",
 ]
 
@@ -491,12 +491,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1111,9 +1111,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "fixedbitset"
@@ -3779,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
@@ -3868,6 +3868,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4781,13 +4787,12 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.10"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+checksum = "2038684e0058edba0d17302619f62eabce4a8e11c6ac59506996a8d79848851d"
 dependencies = [
  "cc",
  "regex",
- "regex-syntax",
  "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
@@ -4795,9 +4800,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-language"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+checksum = "ca0d1bf6fdd806e43ae5198f82f527056d359def39e54e67a0f478ac09dac081"
 
 [[package]]
 name = "trybuild"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage     = "https://supabase.com/"
 keywords     = ["linter", "typechecker", "postgres", "language-server"]
 license      = "MIT"
 repository   = "https://github.com/supabase-community/postgres-language-server"
-rust-version = "1.86.0"
+rust-version = "1.90.0"
 
 [workspace.dependencies]
 # supporting crates unrelated to postgres
@@ -53,7 +53,7 @@ tokio                    = { version = "1.40.0", features = ["full"] }
 tracing                  = { version = "0.1.40", default-features = false, features = ["std"] }
 tracing-bunyan-formatter = { version = "0.3.10 " }
 tracing-subscriber       = "0.3.18"
-tree-sitter              = "0.25.9"
+tree-sitter              = "0.27.0"
 unicode-width            = "0.1.12"
 
 # postgres specific crates

--- a/crates/pgls_analyser/src/lint/safety/avoid_adding_exclusion_constraint.rs
+++ b/crates/pgls_analyser/src/lint/safety/avoid_adding_exclusion_constraint.rs
@@ -46,16 +46,11 @@ impl LinterRule for AvoidAddingExclusionConstraint {
                 for cmd in &stmt.cmds {
                     if let Some(pgls_query::NodeEnum::AlterTableCmd(cmd)) = &cmd.node
                         && cmd.subtype() == pgls_query::protobuf::AlterTableType::AtAddConstraint
-                    {
-                        if let Some(pgls_query::NodeEnum::Constraint(constraint)) =
+                        && let Some(pgls_query::NodeEnum::Constraint(constraint)) =
                             cmd.def.as_ref().and_then(|d| d.node.as_ref())
-                        {
-                            if constraint.contype()
-                                == pgls_query::protobuf::ConstrType::ConstrExclusion
-                            {
-                                diagnostics.push(exclusion_diagnostic());
-                            }
-                        }
+                        && constraint.contype() == pgls_query::protobuf::ConstrType::ConstrExclusion
+                    {
+                        diagnostics.push(exclusion_diagnostic());
                     }
                 }
             }
@@ -63,11 +58,9 @@ impl LinterRule for AvoidAddingExclusionConstraint {
                 for constraint_node in &stmt.constraints {
                     if let Some(pgls_query::NodeEnum::Constraint(constraint)) =
                         &constraint_node.node
+                        && constraint.contype() == pgls_query::protobuf::ConstrType::ConstrExclusion
                     {
-                        if constraint.contype() == pgls_query::protobuf::ConstrType::ConstrExclusion
-                        {
-                            diagnostics.push(exclusion_diagnostic());
-                        }
+                        diagnostics.push(exclusion_diagnostic());
                     }
                 }
             }

--- a/crates/pgls_analyser/src/lint/safety/ban_vacuum_full.rs
+++ b/crates/pgls_analyser/src/lint/safety/ban_vacuum_full.rs
@@ -39,9 +39,10 @@ impl LinterRule for BanVacuumFull {
     fn run(ctx: &LinterRuleContext<Self>) -> Vec<LinterDiagnostic> {
         let mut diagnostics = vec![];
 
-        if let pgls_query::NodeEnum::VacuumStmt(stmt) = &ctx.stmt() {
-            if is_vacuum_full(stmt) {
-                diagnostics.push(
+        if let pgls_query::NodeEnum::VacuumStmt(stmt) = &ctx.stmt()
+            && is_vacuum_full(stmt)
+        {
+            diagnostics.push(
                     LinterDiagnostic::new(
                         rule_category!(),
                         None,
@@ -54,7 +55,6 @@ impl LinterRule for BanVacuumFull {
                         "Use regular VACUUM or pg_repack for online table maintenance without blocking reads and writes.",
                     ),
                 );
-            }
         }
 
         diagnostics

--- a/crates/pgls_analyser/src/lint/safety/changing_column_type.rs
+++ b/crates/pgls_analyser/src/lint/safety/changing_column_type.rs
@@ -54,10 +54,9 @@ impl LinterRule for ChangingColumnType {
                 {
                     if let Some(pgls_query::NodeEnum::ColumnDef(col_def)) =
                         cmd.def.as_ref().and_then(|d| d.node.as_ref())
+                        && is_safe_type_widening(col_def)
                     {
-                        if is_safe_type_widening(col_def) {
-                            continue;
-                        }
+                        continue;
                     }
 
                     diagnostics.push(LinterDiagnostic::new(

--- a/crates/pgls_analyser/src/lint/safety/require_concurrent_reindex.rs
+++ b/crates/pgls_analyser/src/lint/safety/require_concurrent_reindex.rs
@@ -40,9 +40,10 @@ impl LinterRule for RequireConcurrentReindex {
     fn run(ctx: &LinterRuleContext<Self>) -> Vec<LinterDiagnostic> {
         let mut diagnostics = vec![];
 
-        if let pgls_query::NodeEnum::ReindexStmt(stmt) = &ctx.stmt() {
-            if !is_reindex_concurrent(stmt) {
-                diagnostics.push(
+        if let pgls_query::NodeEnum::ReindexStmt(stmt) = &ctx.stmt()
+            && !is_reindex_concurrent(stmt)
+        {
+            diagnostics.push(
                     LinterDiagnostic::new(
                         rule_category!(),
                         None,
@@ -55,7 +56,6 @@ impl LinterRule for RequireConcurrentReindex {
                         "Use REINDEX CONCURRENTLY to rebuild the index without blocking reads and writes.",
                     ),
                 );
-            }
         }
 
         diagnostics

--- a/crates/pgls_analyser/src/linter_context.rs
+++ b/crates/pgls_analyser/src/linter_context.rs
@@ -456,18 +456,16 @@ impl TransactionState {
             for cmd in &alter_stmt.cmds {
                 if let Some(pgls_query::NodeEnum::AlterTableCmd(cmd)) = &cmd.node
                     && cmd.subtype() == pgls_query::protobuf::AlterTableType::AtAddConstraint
-                {
-                    if let Some(pgls_query::NodeEnum::Constraint(constraint)) =
+                    && let Some(pgls_query::NodeEnum::Constraint(constraint)) =
                         cmd.def.as_ref().and_then(|d| d.node.as_ref())
-                    {
-                        if constraint.skip_validation && !constraint.conname.is_empty() {
-                            self.not_valid_constraints.push((
-                                table_schema.clone(),
-                                table_name.clone(),
-                                constraint.conname.clone(),
-                            ));
-                        }
-                    }
+                    && constraint.skip_validation
+                    && !constraint.conname.is_empty()
+                {
+                    self.not_valid_constraints.push((
+                        table_schema.clone(),
+                        table_name.clone(),
+                        constraint.conname.clone(),
+                    ));
                 }
             }
         }

--- a/crates/pgls_completions/src/providers/keywords.rs
+++ b/crates/pgls_completions/src/providers/keywords.rs
@@ -385,7 +385,11 @@ pub fn complete_keywords<'a>(
     }
 
     let keywords_to_try = ALL_KEYWORDS.iter().filter(|kw| {
-        ctx.tree.root_node().has_error() || ctx.possible_keywords_at_position.contains(&kw.name)
+        ctx.tree.root_node().has_error()
+            || ctx
+                .possible_keywords_at_position
+                .iter()
+                .any(|name| name == kw.name)
     });
 
     for kw in keywords_to_try {

--- a/crates/pgls_configuration/src/linter/rules.rs
+++ b/crates/pgls_configuration/src/linter/rules.rs
@@ -480,535 +480,533 @@ impl Safety {
     }
     pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.add_serial_column.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.add_serial_column.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.adding_field_with_default.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.adding_field_with_default.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.adding_foreign_key_constraint.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.adding_foreign_key_constraint.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.adding_not_null_field.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.adding_not_null_field.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.adding_primary_key_constraint.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.adding_primary_key_constraint.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.adding_required_field.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
-            }
+        if let Some(rule) = self.adding_required_field.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.avoid_adding_exclusion_constraint.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
-            }
+        if let Some(rule) = self.avoid_adding_exclusion_constraint.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
-        if let Some(rule) = self.avoid_alter_enum_add_value.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
-            }
+        if let Some(rule) = self.avoid_alter_enum_add_value.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
         }
-        if let Some(rule) = self.avoid_attaching_partition.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
-            }
+        if let Some(rule) = self.avoid_attaching_partition.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
         }
-        if let Some(rule) = self.avoid_create_trigger.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
-            }
+        if let Some(rule) = self.avoid_create_trigger.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
         }
-        if let Some(rule) = self.avoid_enable_disable_trigger.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
-            }
+        if let Some(rule) = self.avoid_enable_disable_trigger.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
         }
-        if let Some(rule) = self.avoid_wide_lock_window.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
-            }
+        if let Some(rule) = self.avoid_wide_lock_window.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
         }
-        if let Some(rule) = self.ban_char_field.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
-            }
+        if let Some(rule) = self.ban_char_field.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
         }
-        if let Some(rule) = self.ban_concurrent_index_creation_in_transaction.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
-            }
+        if let Some(rule) = self.ban_concurrent_index_creation_in_transaction.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
         }
-        if let Some(rule) = self.ban_delete_without_where.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
-            }
+        if let Some(rule) = self.ban_delete_without_where.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
         }
-        if let Some(rule) = self.ban_drop_column.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
-            }
+        if let Some(rule) = self.ban_drop_column.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
         }
-        if let Some(rule) = self.ban_drop_database.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
-            }
+        if let Some(rule) = self.ban_drop_database.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
         }
-        if let Some(rule) = self.ban_drop_not_null.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
-            }
+        if let Some(rule) = self.ban_drop_not_null.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
         }
-        if let Some(rule) = self.ban_drop_schema.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
-            }
+        if let Some(rule) = self.ban_drop_schema.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
         }
-        if let Some(rule) = self.ban_drop_table.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
-            }
+        if let Some(rule) = self.ban_drop_table.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
         }
-        if let Some(rule) = self.ban_drop_trigger.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
-            }
+        if let Some(rule) = self.ban_drop_trigger.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
         }
-        if let Some(rule) = self.ban_truncate.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
-            }
+        if let Some(rule) = self.ban_truncate.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
         }
-        if let Some(rule) = self.ban_truncate_cascade.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
-            }
+        if let Some(rule) = self.ban_truncate_cascade.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
         }
-        if let Some(rule) = self.ban_update_without_where.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
-            }
+        if let Some(rule) = self.ban_update_without_where.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
         }
-        if let Some(rule) = self.ban_vacuum_full.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
-            }
+        if let Some(rule) = self.ban_vacuum_full.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
         }
-        if let Some(rule) = self.changing_column_type.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
-            }
+        if let Some(rule) = self.changing_column_type.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
         }
-        if let Some(rule) = self.concurrent_refresh_matview_lock.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
-            }
+        if let Some(rule) = self.concurrent_refresh_matview_lock.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
         }
-        if let Some(rule) = self.constraint_missing_not_valid.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
-            }
+        if let Some(rule) = self.constraint_missing_not_valid.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
         }
-        if let Some(rule) = self.creating_enum.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
-            }
+        if let Some(rule) = self.creating_enum.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
         }
-        if let Some(rule) = self.disallow_unique_constraint.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
-            }
+        if let Some(rule) = self.disallow_unique_constraint.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
         }
-        if let Some(rule) = self.lock_timeout_warning.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
-            }
+        if let Some(rule) = self.lock_timeout_warning.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
         }
-        if let Some(rule) = self.multiple_alter_table.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
-            }
+        if let Some(rule) = self.multiple_alter_table.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
         }
-        if let Some(rule) = self.prefer_big_int.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
-            }
+        if let Some(rule) = self.prefer_big_int.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
         }
-        if let Some(rule) = self.prefer_bigint_over_int.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
-            }
+        if let Some(rule) = self.prefer_bigint_over_int.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
         }
-        if let Some(rule) = self.prefer_bigint_over_smallint.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
-            }
+        if let Some(rule) = self.prefer_bigint_over_smallint.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
         }
-        if let Some(rule) = self.prefer_identity.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
-            }
+        if let Some(rule) = self.prefer_identity.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
         }
-        if let Some(rule) = self.prefer_jsonb.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
-            }
+        if let Some(rule) = self.prefer_jsonb.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
         }
-        if let Some(rule) = self.prefer_robust_stmts.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
-            }
+        if let Some(rule) = self.prefer_robust_stmts.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
         }
-        if let Some(rule) = self.prefer_text_field.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
-            }
+        if let Some(rule) = self.prefer_text_field.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
         }
-        if let Some(rule) = self.prefer_timestamptz.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
-            }
+        if let Some(rule) = self.prefer_timestamptz.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
         }
-        if let Some(rule) = self.renaming_column.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
-            }
+        if let Some(rule) = self.renaming_column.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
         }
-        if let Some(rule) = self.renaming_table.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
-            }
+        if let Some(rule) = self.renaming_table.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
         }
-        if let Some(rule) = self.require_concurrent_detach_partition.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
-            }
+        if let Some(rule) = self.require_concurrent_detach_partition.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
         }
-        if let Some(rule) = self.require_concurrent_index_creation.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
-            }
+        if let Some(rule) = self.require_concurrent_index_creation.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
         }
-        if let Some(rule) = self.require_concurrent_index_deletion.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
-            }
+        if let Some(rule) = self.require_concurrent_index_deletion.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
         }
-        if let Some(rule) = self.require_concurrent_refresh_matview.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
-            }
+        if let Some(rule) = self.require_concurrent_refresh_matview.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
         }
-        if let Some(rule) = self.require_concurrent_reindex.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
-            }
+        if let Some(rule) = self.require_concurrent_reindex.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
         }
-        if let Some(rule) = self.require_idle_in_transaction_timeout.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
-            }
+        if let Some(rule) = self.require_idle_in_transaction_timeout.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
         }
-        if let Some(rule) = self.require_separate_constraint_validation.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
-            }
+        if let Some(rule) = self.require_separate_constraint_validation.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
         }
-        if let Some(rule) = self.require_statement_timeout.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
-            }
+        if let Some(rule) = self.require_statement_timeout.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
         }
         if let Some(rule) = self
             .running_statement_while_holding_access_exclusive
             .as_ref()
+            && rule.is_enabled()
         {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
-            }
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
         }
-        if let Some(rule) = self.transaction_nesting.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
-            }
+        if let Some(rule) = self.transaction_nesting.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
         }
         index_set
     }
     pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.add_serial_column.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.add_serial_column.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.adding_field_with_default.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.adding_field_with_default.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.adding_foreign_key_constraint.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.adding_foreign_key_constraint.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.adding_not_null_field.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.adding_not_null_field.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.adding_primary_key_constraint.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.adding_primary_key_constraint.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.adding_required_field.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
-            }
+        if let Some(rule) = self.adding_required_field.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.avoid_adding_exclusion_constraint.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
-            }
+        if let Some(rule) = self.avoid_adding_exclusion_constraint.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
-        if let Some(rule) = self.avoid_alter_enum_add_value.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
-            }
+        if let Some(rule) = self.avoid_alter_enum_add_value.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
         }
-        if let Some(rule) = self.avoid_attaching_partition.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
-            }
+        if let Some(rule) = self.avoid_attaching_partition.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
         }
-        if let Some(rule) = self.avoid_create_trigger.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
-            }
+        if let Some(rule) = self.avoid_create_trigger.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
         }
-        if let Some(rule) = self.avoid_enable_disable_trigger.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
-            }
+        if let Some(rule) = self.avoid_enable_disable_trigger.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
         }
-        if let Some(rule) = self.avoid_wide_lock_window.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
-            }
+        if let Some(rule) = self.avoid_wide_lock_window.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
         }
-        if let Some(rule) = self.ban_char_field.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
-            }
+        if let Some(rule) = self.ban_char_field.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
         }
-        if let Some(rule) = self.ban_concurrent_index_creation_in_transaction.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
-            }
+        if let Some(rule) = self.ban_concurrent_index_creation_in_transaction.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
         }
-        if let Some(rule) = self.ban_delete_without_where.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
-            }
+        if let Some(rule) = self.ban_delete_without_where.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
         }
-        if let Some(rule) = self.ban_drop_column.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
-            }
+        if let Some(rule) = self.ban_drop_column.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
         }
-        if let Some(rule) = self.ban_drop_database.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
-            }
+        if let Some(rule) = self.ban_drop_database.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
         }
-        if let Some(rule) = self.ban_drop_not_null.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
-            }
+        if let Some(rule) = self.ban_drop_not_null.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
         }
-        if let Some(rule) = self.ban_drop_schema.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
-            }
+        if let Some(rule) = self.ban_drop_schema.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
         }
-        if let Some(rule) = self.ban_drop_table.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
-            }
+        if let Some(rule) = self.ban_drop_table.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
         }
-        if let Some(rule) = self.ban_drop_trigger.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
-            }
+        if let Some(rule) = self.ban_drop_trigger.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
         }
-        if let Some(rule) = self.ban_truncate.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
-            }
+        if let Some(rule) = self.ban_truncate.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
         }
-        if let Some(rule) = self.ban_truncate_cascade.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
-            }
+        if let Some(rule) = self.ban_truncate_cascade.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
         }
-        if let Some(rule) = self.ban_update_without_where.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
-            }
+        if let Some(rule) = self.ban_update_without_where.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
         }
-        if let Some(rule) = self.ban_vacuum_full.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
-            }
+        if let Some(rule) = self.ban_vacuum_full.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
         }
-        if let Some(rule) = self.changing_column_type.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
-            }
+        if let Some(rule) = self.changing_column_type.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
         }
-        if let Some(rule) = self.concurrent_refresh_matview_lock.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
-            }
+        if let Some(rule) = self.concurrent_refresh_matview_lock.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
         }
-        if let Some(rule) = self.constraint_missing_not_valid.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
-            }
+        if let Some(rule) = self.constraint_missing_not_valid.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
         }
-        if let Some(rule) = self.creating_enum.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
-            }
+        if let Some(rule) = self.creating_enum.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
         }
-        if let Some(rule) = self.disallow_unique_constraint.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
-            }
+        if let Some(rule) = self.disallow_unique_constraint.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
         }
-        if let Some(rule) = self.lock_timeout_warning.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
-            }
+        if let Some(rule) = self.lock_timeout_warning.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
         }
-        if let Some(rule) = self.multiple_alter_table.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
-            }
+        if let Some(rule) = self.multiple_alter_table.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
         }
-        if let Some(rule) = self.prefer_big_int.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
-            }
+        if let Some(rule) = self.prefer_big_int.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
         }
-        if let Some(rule) = self.prefer_bigint_over_int.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
-            }
+        if let Some(rule) = self.prefer_bigint_over_int.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
         }
-        if let Some(rule) = self.prefer_bigint_over_smallint.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
-            }
+        if let Some(rule) = self.prefer_bigint_over_smallint.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
         }
-        if let Some(rule) = self.prefer_identity.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
-            }
+        if let Some(rule) = self.prefer_identity.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
         }
-        if let Some(rule) = self.prefer_jsonb.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
-            }
+        if let Some(rule) = self.prefer_jsonb.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
         }
-        if let Some(rule) = self.prefer_robust_stmts.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
-            }
+        if let Some(rule) = self.prefer_robust_stmts.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
         }
-        if let Some(rule) = self.prefer_text_field.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
-            }
+        if let Some(rule) = self.prefer_text_field.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
         }
-        if let Some(rule) = self.prefer_timestamptz.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
-            }
+        if let Some(rule) = self.prefer_timestamptz.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
         }
-        if let Some(rule) = self.renaming_column.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
-            }
+        if let Some(rule) = self.renaming_column.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
         }
-        if let Some(rule) = self.renaming_table.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
-            }
+        if let Some(rule) = self.renaming_table.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
         }
-        if let Some(rule) = self.require_concurrent_detach_partition.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
-            }
+        if let Some(rule) = self.require_concurrent_detach_partition.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
         }
-        if let Some(rule) = self.require_concurrent_index_creation.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
-            }
+        if let Some(rule) = self.require_concurrent_index_creation.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
         }
-        if let Some(rule) = self.require_concurrent_index_deletion.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
-            }
+        if let Some(rule) = self.require_concurrent_index_deletion.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
         }
-        if let Some(rule) = self.require_concurrent_refresh_matview.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
-            }
+        if let Some(rule) = self.require_concurrent_refresh_matview.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
         }
-        if let Some(rule) = self.require_concurrent_reindex.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
-            }
+        if let Some(rule) = self.require_concurrent_reindex.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
         }
-        if let Some(rule) = self.require_idle_in_transaction_timeout.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
-            }
+        if let Some(rule) = self.require_idle_in_transaction_timeout.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
         }
-        if let Some(rule) = self.require_separate_constraint_validation.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
-            }
+        if let Some(rule) = self.require_separate_constraint_validation.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
         }
-        if let Some(rule) = self.require_statement_timeout.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
-            }
+        if let Some(rule) = self.require_statement_timeout.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
         }
         if let Some(rule) = self
             .running_statement_while_holding_access_exclusive
             .as_ref()
+            && rule.is_disabled()
         {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
-            }
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
         }
-        if let Some(rule) = self.transaction_nesting.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
-            }
+        if let Some(rule) = self.transaction_nesting.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
         }
         index_set
     }
@@ -1319,10 +1317,10 @@ pub fn push_to_analyser_rules(
 ) {
     if let Some(rules) = rules.safety.as_ref() {
         for rule_name in Safety::GROUP_RULES {
-            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
-                if let Some(rule_key) = metadata.find_rule("safety", rule_name) {
-                    analyser_rules.push_rule(rule_key, rule_options);
-                }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name)
+                && let Some(rule_key) = metadata.find_rule("safety", rule_name)
+            {
+                analyser_rules.push_rule(rule_key, rule_options);
             }
         }
     }

--- a/crates/pgls_configuration/src/pglinter/rules.rs
+++ b/crates/pgls_configuration/src/pglinter/rules.rs
@@ -302,129 +302,129 @@ impl Base {
     }
     pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.composite_primary_key_too_many_columns.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.composite_primary_key_too_many_columns.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.how_many_objects_with_uppercase.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.how_many_objects_with_uppercase.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.how_many_redudant_index.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.how_many_redudant_index.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.how_many_table_without_index_on_fk.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.how_many_table_without_index_on_fk.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.how_many_table_without_primary_key.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.how_many_table_without_primary_key.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.how_many_tables_never_selected.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
-            }
+        if let Some(rule) = self.how_many_tables_never_selected.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.how_many_tables_with_fk_mismatch.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
-            }
+        if let Some(rule) = self.how_many_tables_with_fk_mismatch.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
-        if let Some(rule) = self.how_many_tables_with_fk_outside_schema.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
-            }
+        if let Some(rule) = self.how_many_tables_with_fk_outside_schema.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
         }
-        if let Some(rule) = self.how_many_tables_with_reserved_keywords.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
-            }
+        if let Some(rule) = self.how_many_tables_with_reserved_keywords.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
         }
-        if let Some(rule) = self.how_many_tables_with_same_trigger.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
-            }
+        if let Some(rule) = self.how_many_tables_with_same_trigger.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
         }
-        if let Some(rule) = self.how_many_unused_index.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
-            }
+        if let Some(rule) = self.how_many_unused_index.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
         }
-        if let Some(rule) = self.several_table_owner_in_schema.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
-            }
+        if let Some(rule) = self.several_table_owner_in_schema.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
         }
         index_set
     }
     pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.composite_primary_key_too_many_columns.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.composite_primary_key_too_many_columns.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.how_many_objects_with_uppercase.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.how_many_objects_with_uppercase.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.how_many_redudant_index.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.how_many_redudant_index.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.how_many_table_without_index_on_fk.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.how_many_table_without_index_on_fk.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.how_many_table_without_primary_key.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.how_many_table_without_primary_key.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.how_many_tables_never_selected.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
-            }
+        if let Some(rule) = self.how_many_tables_never_selected.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.how_many_tables_with_fk_mismatch.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
-            }
+        if let Some(rule) = self.how_many_tables_with_fk_mismatch.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
-        if let Some(rule) = self.how_many_tables_with_fk_outside_schema.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
-            }
+        if let Some(rule) = self.how_many_tables_with_fk_outside_schema.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
         }
-        if let Some(rule) = self.how_many_tables_with_reserved_keywords.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
-            }
+        if let Some(rule) = self.how_many_tables_with_reserved_keywords.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
         }
-        if let Some(rule) = self.how_many_tables_with_same_trigger.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
-            }
+        if let Some(rule) = self.how_many_tables_with_same_trigger.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
         }
-        if let Some(rule) = self.how_many_unused_index.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
-            }
+        if let Some(rule) = self.how_many_unused_index.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
         }
-        if let Some(rule) = self.several_table_owner_in_schema.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
-            }
+        if let Some(rule) = self.several_table_owner_in_schema.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
         }
         index_set
     }
@@ -581,51 +581,47 @@ impl Cluster {
     }
     pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.password_encryption_is_md5.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.password_encryption_is_md5.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
         if let Some(rule) = self
             .pg_hba_entries_with_method_trust_or_password_should_not_exists
             .as_ref()
+            && rule.is_enabled()
         {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
         if let Some(rule) = self
             .pg_hba_entries_with_method_trust_should_not_exists
             .as_ref()
+            && rule.is_enabled()
         {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
         index_set
     }
     pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.password_encryption_is_md5.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.password_encryption_is_md5.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
         if let Some(rule) = self
             .pg_hba_entries_with_method_trust_or_password_should_not_exists
             .as_ref()
+            && rule.is_disabled()
         {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
         if let Some(rule) = self
             .pg_hba_entries_with_method_trust_should_not_exists
             .as_ref()
+            && rule.is_disabled()
         {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
         index_set
     }
@@ -748,59 +744,59 @@ impl Schema {
     }
     pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.owner_schema_is_internal_role.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.owner_schema_is_internal_role.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.schema_owner_do_not_match_table_owner.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.schema_owner_do_not_match_table_owner.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.schema_prefixed_or_suffixed_with_envt.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.schema_prefixed_or_suffixed_with_envt.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.schema_with_default_role_not_granted.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.schema_with_default_role_not_granted.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.unsecured_public_schema.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.unsecured_public_schema.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
         index_set
     }
     pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.owner_schema_is_internal_role.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.owner_schema_is_internal_role.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.schema_owner_do_not_match_table_owner.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.schema_owner_do_not_match_table_owner.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.schema_prefixed_or_suffixed_with_envt.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.schema_prefixed_or_suffixed_with_envt.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.schema_with_default_role_not_granted.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.schema_with_default_role_not_granted.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.unsecured_public_schema.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.unsecured_public_schema.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
         index_set
     }
@@ -876,28 +872,28 @@ pub fn push_to_analyser_rules(
 ) {
     if let Some(rules) = rules.base.as_ref() {
         for rule_name in Base::GROUP_RULES {
-            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
-                if let Some(rule_key) = metadata.find_rule("base", rule_name) {
-                    analyser_rules.push_rule(rule_key, rule_options);
-                }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name)
+                && let Some(rule_key) = metadata.find_rule("base", rule_name)
+            {
+                analyser_rules.push_rule(rule_key, rule_options);
             }
         }
     }
     if let Some(rules) = rules.cluster.as_ref() {
         for rule_name in Cluster::GROUP_RULES {
-            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
-                if let Some(rule_key) = metadata.find_rule("cluster", rule_name) {
-                    analyser_rules.push_rule(rule_key, rule_options);
-                }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name)
+                && let Some(rule_key) = metadata.find_rule("cluster", rule_name)
+            {
+                analyser_rules.push_rule(rule_key, rule_options);
             }
         }
     }
     if let Some(rules) = rules.schema.as_ref() {
         for rule_name in Schema::GROUP_RULES {
-            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
-                if let Some(rule_key) = metadata.find_rule("schema", rule_name) {
-                    analyser_rules.push_rule(rule_key, rule_options);
-                }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name)
+                && let Some(rule_key) = metadata.find_rule("schema", rule_name)
+            {
+                analyser_rules.push_rule(rule_key, rule_options);
             }
         }
     }

--- a/crates/pgls_configuration/src/splinter/rules.rs
+++ b/crates/pgls_configuration/src/splinter/rules.rs
@@ -259,79 +259,79 @@ impl Performance {
     }
     pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.auth_rls_initplan.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.auth_rls_initplan.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.duplicate_index.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.duplicate_index.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.multiple_permissive_policies.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.multiple_permissive_policies.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.no_primary_key.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.no_primary_key.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.table_bloat.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.table_bloat.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.unindexed_foreign_keys.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
-            }
+        if let Some(rule) = self.unindexed_foreign_keys.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.unused_index.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
-            }
+        if let Some(rule) = self.unused_index.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
         index_set
     }
     pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.auth_rls_initplan.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.auth_rls_initplan.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.duplicate_index.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.duplicate_index.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.multiple_permissive_policies.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.multiple_permissive_policies.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.no_primary_key.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.no_primary_key.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.table_bloat.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.table_bloat.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.unindexed_foreign_keys.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
-            }
+        if let Some(rule) = self.unindexed_foreign_keys.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.unused_index.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
-            }
+        if let Some(rule) = self.unused_index.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
         index_set
     }
@@ -413,82 +413,75 @@ impl Performance {
         &self,
     ) -> rustc_hash::FxHashMap<&'static str, pgls_matcher::Matcher> {
         let mut matchers = rustc_hash::FxHashMap::default();
-        if let Some(conf) = &self.auth_rls_initplan {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("authRlsInitplan", m);
-                }
+        if let Some(conf) = &self.auth_rls_initplan
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("authRlsInitplan", m);
         }
-        if let Some(conf) = &self.duplicate_index {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("duplicateIndex", m);
-                }
+        if let Some(conf) = &self.duplicate_index
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("duplicateIndex", m);
         }
-        if let Some(conf) = &self.multiple_permissive_policies {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("multiplePermissivePolicies", m);
-                }
+        if let Some(conf) = &self.multiple_permissive_policies
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("multiplePermissivePolicies", m);
         }
-        if let Some(conf) = &self.no_primary_key {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("noPrimaryKey", m);
-                }
+        if let Some(conf) = &self.no_primary_key
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("noPrimaryKey", m);
         }
-        if let Some(conf) = &self.table_bloat {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("tableBloat", m);
-                }
+        if let Some(conf) = &self.table_bloat
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("tableBloat", m);
         }
-        if let Some(conf) = &self.unindexed_foreign_keys {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("unindexedForeignKeys", m);
-                }
+        if let Some(conf) = &self.unindexed_foreign_keys
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("unindexedForeignKeys", m);
         }
-        if let Some(conf) = &self.unused_index {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("unusedIndex", m);
-                }
+        if let Some(conf) = &self.unused_index
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("unusedIndex", m);
         }
         matchers
     }
@@ -628,169 +621,169 @@ impl Security {
     }
     pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.auth_users_exposed.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.auth_users_exposed.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.extension_in_public.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.extension_in_public.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.extension_versions_outdated.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.extension_versions_outdated.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.fkey_to_auth_unique.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.fkey_to_auth_unique.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.foreign_table_in_api.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.foreign_table_in_api.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.function_search_path_mutable.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
-            }
+        if let Some(rule) = self.function_search_path_mutable.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.insecure_queue_exposed_in_api.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
-            }
+        if let Some(rule) = self.insecure_queue_exposed_in_api.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
-        if let Some(rule) = self.materialized_view_in_api.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
-            }
+        if let Some(rule) = self.materialized_view_in_api.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
         }
-        if let Some(rule) = self.policy_exists_rls_disabled.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
-            }
+        if let Some(rule) = self.policy_exists_rls_disabled.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
         }
-        if let Some(rule) = self.rls_disabled_in_public.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
-            }
+        if let Some(rule) = self.rls_disabled_in_public.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
         }
-        if let Some(rule) = self.rls_enabled_no_policy.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
-            }
+        if let Some(rule) = self.rls_enabled_no_policy.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
         }
-        if let Some(rule) = self.rls_policy_always_true.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
-            }
+        if let Some(rule) = self.rls_policy_always_true.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
         }
-        if let Some(rule) = self.rls_references_user_metadata.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
-            }
+        if let Some(rule) = self.rls_references_user_metadata.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
         }
-        if let Some(rule) = self.security_definer_view.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
-            }
+        if let Some(rule) = self.security_definer_view.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
         }
-        if let Some(rule) = self.sensitive_columns_exposed.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
-            }
+        if let Some(rule) = self.sensitive_columns_exposed.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
         }
-        if let Some(rule) = self.unsupported_reg_types.as_ref() {
-            if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
-            }
+        if let Some(rule) = self.unsupported_reg_types.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
         }
         index_set
     }
     pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.auth_users_exposed.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
+        if let Some(rule) = self.auth_users_exposed.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.extension_in_public.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
+        if let Some(rule) = self.extension_in_public.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.extension_versions_outdated.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
+        if let Some(rule) = self.extension_versions_outdated.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.fkey_to_auth_unique.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
-            }
+        if let Some(rule) = self.fkey_to_auth_unique.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.foreign_table_in_api.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
-            }
+        if let Some(rule) = self.foreign_table_in_api.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.function_search_path_mutable.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
-            }
+        if let Some(rule) = self.function_search_path_mutable.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.insecure_queue_exposed_in_api.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
-            }
+        if let Some(rule) = self.insecure_queue_exposed_in_api.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
-        if let Some(rule) = self.materialized_view_in_api.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
-            }
+        if let Some(rule) = self.materialized_view_in_api.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
         }
-        if let Some(rule) = self.policy_exists_rls_disabled.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
-            }
+        if let Some(rule) = self.policy_exists_rls_disabled.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
         }
-        if let Some(rule) = self.rls_disabled_in_public.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
-            }
+        if let Some(rule) = self.rls_disabled_in_public.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
         }
-        if let Some(rule) = self.rls_enabled_no_policy.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
-            }
+        if let Some(rule) = self.rls_enabled_no_policy.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
         }
-        if let Some(rule) = self.rls_policy_always_true.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
-            }
+        if let Some(rule) = self.rls_policy_always_true.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
         }
-        if let Some(rule) = self.rls_references_user_metadata.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
-            }
+        if let Some(rule) = self.rls_references_user_metadata.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
         }
-        if let Some(rule) = self.security_definer_view.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
-            }
+        if let Some(rule) = self.security_definer_view.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
         }
-        if let Some(rule) = self.sensitive_columns_exposed.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
-            }
+        if let Some(rule) = self.sensitive_columns_exposed.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
         }
-        if let Some(rule) = self.unsupported_reg_types.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
-            }
+        if let Some(rule) = self.unsupported_reg_types.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
         }
         index_set
     }
@@ -917,181 +910,165 @@ impl Security {
         &self,
     ) -> rustc_hash::FxHashMap<&'static str, pgls_matcher::Matcher> {
         let mut matchers = rustc_hash::FxHashMap::default();
-        if let Some(conf) = &self.auth_users_exposed {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("authUsersExposed", m);
-                }
+        if let Some(conf) = &self.auth_users_exposed
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("authUsersExposed", m);
         }
-        if let Some(conf) = &self.extension_in_public {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("extensionInPublic", m);
-                }
+        if let Some(conf) = &self.extension_in_public
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("extensionInPublic", m);
         }
-        if let Some(conf) = &self.extension_versions_outdated {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("extensionVersionsOutdated", m);
-                }
+        if let Some(conf) = &self.extension_versions_outdated
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("extensionVersionsOutdated", m);
         }
-        if let Some(conf) = &self.fkey_to_auth_unique {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("fkeyToAuthUnique", m);
-                }
+        if let Some(conf) = &self.fkey_to_auth_unique
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("fkeyToAuthUnique", m);
         }
-        if let Some(conf) = &self.foreign_table_in_api {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("foreignTableInApi", m);
-                }
+        if let Some(conf) = &self.foreign_table_in_api
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("foreignTableInApi", m);
         }
-        if let Some(conf) = &self.function_search_path_mutable {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("functionSearchPathMutable", m);
-                }
+        if let Some(conf) = &self.function_search_path_mutable
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("functionSearchPathMutable", m);
         }
-        if let Some(conf) = &self.insecure_queue_exposed_in_api {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("insecureQueueExposedInApi", m);
-                }
+        if let Some(conf) = &self.insecure_queue_exposed_in_api
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("insecureQueueExposedInApi", m);
         }
-        if let Some(conf) = &self.materialized_view_in_api {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("materializedViewInApi", m);
-                }
+        if let Some(conf) = &self.materialized_view_in_api
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("materializedViewInApi", m);
         }
-        if let Some(conf) = &self.policy_exists_rls_disabled {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("policyExistsRlsDisabled", m);
-                }
+        if let Some(conf) = &self.policy_exists_rls_disabled
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("policyExistsRlsDisabled", m);
         }
-        if let Some(conf) = &self.rls_disabled_in_public {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("rlsDisabledInPublic", m);
-                }
+        if let Some(conf) = &self.rls_disabled_in_public
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("rlsDisabledInPublic", m);
         }
-        if let Some(conf) = &self.rls_enabled_no_policy {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("rlsEnabledNoPolicy", m);
-                }
+        if let Some(conf) = &self.rls_enabled_no_policy
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("rlsEnabledNoPolicy", m);
         }
-        if let Some(conf) = &self.rls_policy_always_true {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("rlsPolicyAlwaysTrue", m);
-                }
+        if let Some(conf) = &self.rls_policy_always_true
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("rlsPolicyAlwaysTrue", m);
         }
-        if let Some(conf) = &self.rls_references_user_metadata {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("rlsReferencesUserMetadata", m);
-                }
+        if let Some(conf) = &self.rls_references_user_metadata
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("rlsReferencesUserMetadata", m);
         }
-        if let Some(conf) = &self.security_definer_view {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("securityDefinerView", m);
-                }
+        if let Some(conf) = &self.security_definer_view
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("securityDefinerView", m);
         }
-        if let Some(conf) = &self.sensitive_columns_exposed {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("sensitiveColumnsExposed", m);
-                }
+        if let Some(conf) = &self.sensitive_columns_exposed
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("sensitiveColumnsExposed", m);
         }
-        if let Some(conf) = &self.unsupported_reg_types {
-            if let Some(options) = conf.get_options_ref() {
-                if !options.ignore.is_empty() {
-                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                    for p in &options.ignore {
-                        let _ = m.add_pattern(p);
-                    }
-                    matchers.insert("unsupportedRegTypes", m);
-                }
+        if let Some(conf) = &self.unsupported_reg_types
+            && let Some(options) = conf.get_options_ref()
+            && !options.ignore.is_empty()
+        {
+            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+            for p in &options.ignore {
+                let _ = m.add_pattern(p);
             }
+            matchers.insert("unsupportedRegTypes", m);
         }
         matchers
     }
@@ -1104,19 +1081,19 @@ pub fn push_to_analyser_rules(
 ) {
     if let Some(rules) = rules.performance.as_ref() {
         for rule_name in Performance::GROUP_RULES {
-            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
-                if let Some(rule_key) = metadata.find_rule("performance", rule_name) {
-                    analyser_rules.push_rule(rule_key, rule_options);
-                }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name)
+                && let Some(rule_key) = metadata.find_rule("performance", rule_name)
+            {
+                analyser_rules.push_rule(rule_key, rule_options);
             }
         }
     }
     if let Some(rules) = rules.security.as_ref() {
         for rule_name in Security::GROUP_RULES {
-            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
-                if let Some(rule_key) = metadata.find_rule("security", rule_name) {
-                    analyser_rules.push_rule(rule_key, rule_options);
-                }
+            if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name)
+                && let Some(rule_key) = metadata.find_rule("security", rule_name)
+            {
+                analyser_rules.push_rule(rule_key, rule_options);
             }
         }
     }

--- a/crates/pgls_configuration_macros/src/partial_derive/mod.rs
+++ b/crates/pgls_configuration_macros/src/partial_derive/mod.rs
@@ -111,11 +111,11 @@ pub(crate) fn generate_partial(input: DeriveInput) -> TokenStream {
                 Some(PartialType::Literal(ty)) => ty.clone(),
                 Some(PartialType::Prefixed) => {
                     let mut ty = ty.clone();
-                    if let Type::Path(type_path) = &mut ty {
-                        if let Some(segment) = type_path.path.segments.first_mut() {
-                            segment.ident =
-                                Ident::new(&format!("Partial{}", segment.ident), Span::call_site())
-                        }
+                    if let Type::Path(type_path) = &mut ty
+                        && let Some(segment) = type_path.path.segments.first_mut()
+                    {
+                        segment.ident =
+                            Ident::new(&format!("Partial{}", segment.ident), Span::call_site())
                     }
                     ty
                 }

--- a/crates/pgls_treesitter/src/context/mod.rs
+++ b/crates/pgls_treesitter/src/context/mod.rs
@@ -126,7 +126,7 @@ pub struct TreesitterContext<'a> {
     pub is_invocation: bool,
     pub wrapping_statement_range: Option<tree_sitter::Range>,
 
-    pub possible_keywords_at_position: Vec<&'static str>,
+    pub possible_keywords_at_position: Vec<String>,
     pub previous_clause: Option<tree_sitter::Node<'a>>,
     pub current_clause: Option<tree_sitter::Node<'a>>,
 
@@ -447,7 +447,7 @@ impl<'a> TreesitterContext<'a> {
         if let Some(mut lookahead_iterator) = language.lookahead_iterator(parse_state) {
             self.possible_keywords_at_position = lookahead_iterator
                 .iter_names()
-                .filter_map(|kw| kw.strip_prefix("keyword_"))
+                .filter_map(|kw| kw.strip_prefix("keyword_").map(str::to_owned))
                 .collect();
         }
     }

--- a/crates/pgls_treesitter/src/queries/insert_columns.rs
+++ b/crates/pgls_treesitter/src/queries/insert_columns.rs
@@ -55,8 +55,8 @@ impl<'a> Query<'a> for InsertColumnMatch<'a> {
         let mut to_return = vec![];
 
         matches.for_each(|m| {
-            if m.captures.len() == 1 {
-                let capture = m.captures[0].node;
+            if m.captures().len() == 1 {
+                let capture = m.captures()[0].node;
                 to_return.push(QueryResult::InsertClauseColumns(InsertColumnMatch {
                     column: capture,
                 }));

--- a/crates/pgls_treesitter/src/queries/object_references.rs
+++ b/crates/pgls_treesitter/src/queries/object_references.rs
@@ -63,19 +63,20 @@ pub fn parts_of_reference_query<'a>(
     let mut matches = cursor.matches(&PARTS_OF_REFERENCE_QUERY, node, stmt.as_bytes());
 
     if let Some(next) = matches.next() {
-        if next.captures.len() == 1 {
-            return Some((None, None, next.captures[0].node));
+        let captures = next.captures();
+        if captures.len() == 1 {
+            return Some((None, None, captures[0].node));
         };
 
-        if next.captures.len() == 2 {
-            return Some((None, Some(next.captures[0].node), next.captures[1].node));
+        if captures.len() == 2 {
+            return Some((None, Some(captures[0].node), captures[1].node));
         };
 
-        if next.captures.len() == 3 {
+        if captures.len() == 3 {
             return Some((
-                Some(next.captures[0].node),
-                Some(next.captures[1].node),
-                next.captures[2].node,
+                Some(captures[0].node),
+                Some(captures[1].node),
+                captures[2].node,
             ));
         };
     }

--- a/crates/pgls_treesitter/src/queries/parameters.rs
+++ b/crates/pgls_treesitter/src/queries/parameters.rs
@@ -67,7 +67,7 @@ impl<'a> Query<'a> for ParameterMatch<'a> {
         let mut result = vec![];
 
         matches.for_each(|m| {
-            let captures = m.captures;
+            let captures = m.captures();
 
             // We expect exactly one capture for a parameter
             if captures.len() == 1 {

--- a/crates/pgls_treesitter/src/queries/relations.rs
+++ b/crates/pgls_treesitter/src/queries/relations.rs
@@ -65,7 +65,7 @@ impl<'a> Query<'a> for RelationMatch<'a> {
         let mut to_return = vec![];
 
         matches.for_each(|m| {
-            m.captures.iter().for_each(|capture| {
+            m.captures().iter().for_each(|capture| {
                 if let Some((_, schema, table)) = parts_of_reference_query(capture.node, stmt) {
                     to_return.push(QueryResult::Relation(RelationMatch { schema, table }));
                 }

--- a/crates/pgls_treesitter/src/queries/select_columns.rs
+++ b/crates/pgls_treesitter/src/queries/select_columns.rs
@@ -71,7 +71,7 @@ impl<'a> Query<'a> for SelectColumnMatch<'a> {
         let mut to_return = vec![];
 
         matches.for_each(|m| {
-            m.captures.iter().for_each(|capture| {
+            m.captures().iter().for_each(|capture| {
                 if let Some((schema, alias, column)) = parts_of_reference_query(capture.node, stmt)
                 {
                     to_return.push(QueryResult::SelectClauseColumns(SelectColumnMatch {

--- a/crates/pgls_treesitter/src/queries/table_aliases.rs
+++ b/crates/pgls_treesitter/src/queries/table_aliases.rs
@@ -76,9 +76,9 @@ impl<'a> Query<'a> for TableAliasMatch<'a> {
         let mut to_return = vec![];
 
         matches.for_each(|m| {
-            if m.captures.len() == 2 {
-                let obj_ref = m.captures[0].node;
-                let alias = m.captures[1].node;
+            if m.captures().len() == 2 {
+                let obj_ref = m.captures()[0].node;
+                let alias = m.captures()[1].node;
                 if let Some((_, schema, table)) = parts_of_reference_query(obj_ref, stmt) {
                     to_return.push(QueryResult::TableAliases(TableAliasMatch {
                         schema,

--- a/crates/pgls_treesitter/src/queries/where_columns.rs
+++ b/crates/pgls_treesitter/src/queries/where_columns.rs
@@ -85,13 +85,13 @@ impl<'a> Query<'a> for WhereColumnMatch<'a> {
 
             let binary_expr_matches = binary_cursor.matches(
                 &BINARY_EXPR_QUERY,
-                where_match.captures[0].node,
+                where_match.captures()[0].node,
                 stmt.as_bytes(),
             );
 
             binary_expr_matches.for_each(|m| {
-                if m.captures.len() == 1 {
-                    let capture = m.captures[0].node;
+                if m.captures().len() == 1 {
+                    let capture = m.captures()[0].node;
 
                     if let Some((schema, alias, column)) = parts_of_reference_query(capture, stmt) {
                         to_return.push(QueryResult::WhereClauseColumns(WhereColumnMatch {

--- a/crates/pgls_treesitter_grammar/benches/lookahead_iter.rs
+++ b/crates/pgls_treesitter_grammar/benches/lookahead_iter.rs
@@ -16,7 +16,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     .expect("Invalid Parse State");
 
                 // contains about 106 nodes for ParseState 32
-                let it: Vec<&'static str> = lh_iterator.iter_names().collect();
+                let it: Vec<&str> = lh_iterator.iter_names().collect();
 
                 black_box(it);
             });

--- a/crates/pgls_treesitter_grammar/benches/parsing_with_existing_tree.rs
+++ b/crates/pgls_treesitter_grammar/benches/parsing_with_existing_tree.rs
@@ -31,7 +31,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let tbl_token = matches
             .next()
             .expect("invalid TS query for the SQL")
-            .captures[0]
+            .captures()[0]
             .node;
 
         let token_to_replace = black_box("clients");
@@ -129,7 +129,7 @@ where
         let tbl_token = matches
             .next()
             .expect("invalid TS query for the SQL")
-            .captures[0]
+            .captures()[0]
             .node;
 
         let token_to_replace = black_box("and");
@@ -266,7 +266,7 @@ where
         let tbl_token = matches
             .next()
             .expect("invalid TS query for the SQL")
-            .captures[0]
+            .captures()[0]
             .node;
 
         let token_to_replace = black_box("not in");

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751510438,
-        "narHash": "sha256-m8PjOoyyCR4nhqtHEBP1tB/jF+gJYYguSZmUmVTEAQE=",
+        "lastModified": 1788678114,
+        "narHash": "sha256-pcqbpV4ZI79al6KAlr+WJjaEo/PYfgctRlG43D5BSJM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7f415261f298656f8164bd636c0dc05af4e95b6b",
+        "rev": "4748ec2f5ed4a881474ed4c98aa71a5308cdac8d",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 profile = "default"
-channel = "1.88.0"
+channel = "1.90.0"
 targets = ["wasm32-unknown-emscripten"]

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -564,10 +564,10 @@ fn generate_lint_rules_file(
             #(
                 if let Some(rules) = rules.#group_idents.as_ref() {
                     for rule_name in #group_pascal_idents::GROUP_RULES {
-                        if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name) {
-                            if let Some(rule_key) = metadata.find_rule(#group_strings, rule_name) {
-                                analyser_rules.push_rule(rule_key, rule_options);
-                            }
+                        if let Some((_, Some(rule_options))) = rules.get_rule_configuration(rule_name)
+                            && let Some(rule_key) = metadata.find_rule(#group_strings, rule_name)
+                        {
+                            analyser_rules.push_rule(rule_key, rule_options);
                         }
                     }
                 }
@@ -629,16 +629,15 @@ fn generate_lint_group_struct(
         if tool_name == "splinter" {
             let rule_str = Literal::string(rule);
             splinter_ignore_matcher_lines.push(quote! {
-                if let Some(conf) = &self.#rule_identifier {
-                    if let Some(options) = conf.get_options_ref() {
-                        if !options.ignore.is_empty() {
-                            let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
-                            for p in &options.ignore {
-                                let _ = m.add_pattern(p);
-                            }
-                            matchers.insert(#rule_str, m);
-                        }
+                if let Some(conf) = &self.#rule_identifier
+                    && let Some(options) = conf.get_options_ref()
+                    && !options.ignore.is_empty()
+                {
+                    let mut m = pgls_matcher::Matcher::new(pgls_matcher::MatchOptions::default());
+                    for p in &options.ignore {
+                        let _ = m.add_pattern(p);
                     }
+                    matchers.insert(#rule_str, m);
                 }
             });
         }
@@ -662,24 +661,24 @@ fn generate_lint_group_struct(
         });
 
         rule_enabled_check_line.push(quote! {
-            if let Some(rule) = self.#rule_identifier.as_ref() {
-                if rule.is_enabled() {
-                    index_set.insert(RuleFilter::Rule(
-                        Self::GROUP_NAME,
-                        Self::GROUP_RULES[#rule_position],
-                    ));
-                }
+            if let Some(rule) = self.#rule_identifier.as_ref()
+                && rule.is_enabled()
+            {
+                index_set.insert(RuleFilter::Rule(
+                    Self::GROUP_NAME,
+                    Self::GROUP_RULES[#rule_position],
+                ));
             }
         });
 
         rule_disabled_check_line.push(quote! {
-            if let Some(rule) = self.#rule_identifier.as_ref() {
-                if rule.is_disabled() {
-                    index_set.insert(RuleFilter::Rule(
-                        Self::GROUP_NAME,
-                        Self::GROUP_RULES[#rule_position],
-                    ));
-                }
+            if let Some(rule) = self.#rule_identifier.as_ref()
+                && rule.is_disabled()
+            {
+                index_set.insert(RuleFilter::Rule(
+                    Self::GROUP_NAME,
+                    Self::GROUP_RULES[#rule_position],
+                ));
             }
         });
 
@@ -1138,13 +1137,13 @@ fn generate_action_group_struct(
         });
 
         rule_enabled_check_line.push(quote! {
-            if let Some(rule) = self.#rule_identifier.as_ref() {
-                if rule.is_enabled() {
-                    index_set.insert(RuleFilter::Rule(
-                        Self::GROUP_NAME,
-                        Self::GROUP_RULES[#rule_position],
-                    ));
-                }
+            if let Some(rule) = self.#rule_identifier.as_ref()
+                && rule.is_enabled()
+            {
+                index_set.insert(RuleFilter::Rule(
+                    Self::GROUP_NAME,
+                    Self::GROUP_RULES[#rule_position],
+                ));
             }
         });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dependency update.

## What is the current behavior?

The project uses tree-sitter 0.25.

## What is the new behavior?

Upgrades tree-sitter to 0.27 and adapts query capture access and keyword string ownership to the updated API.

## Additional context

Raises the minimum Rust version and toolchain to `1.90.0`, as required by tree-sitter 0.27.
