### PR TITLE
Make query compatible with postgres 19

### DIFF
--- a/crates/pgls_schema_cache/src/queries/extensions.sql
+++ b/crates/pgls_schema_cache/src/queries/extensions.sql
@@ -5,6 +5,6 @@ SELECT
   x.extversion AS installed_version,
   e.comment
 FROM
-  pg_available_extensions() e(name, default_version, comment)
+  pg_available_extensions() e
   LEFT JOIN pg_extension x ON e.name = x.extname
   LEFT JOIN pg_namespace n ON x.extnamespace = n.oid


### PR DESCRIPTION
postgres 19beta1 introduces a new column `location` in the `pg_available_extensions` view.  https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=f3c9e341c

But because its columns are referenced positionally, it breaks this query in 19.   Here is a fix that works on both 18 and 19.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

  ✖ Database error: column reference "comment" is ambiguous
and
"cannot connect to database"

