### PR TITLE
fix(splitter): preserve blank lines in parsable SQL

### DIFF
--- a/crates/pgls_lexer/src/lexed.rs
+++ b/crates/pgls_lexer/src/lexed.rs
@@ -30,6 +30,7 @@ pub struct Lexed<'a> {
     pub(crate) start: Vec<u32>,
     pub(crate) error: Vec<LexError>,
     pub(crate) line_ending_counts: Vec<usize>,
+    pub(crate) has_blank_line: bool,
 }
 
 impl Lexed<'_> {
@@ -69,6 +70,11 @@ impl Lexed<'_> {
         );
         assert!(self.kind(idx) == SyntaxKind::LINE_ENDING);
         self.line_ending_counts[idx]
+    }
+
+    /// Returns whether the source contains at least one blank line.
+    pub fn has_blank_line(&self) -> bool {
+        self.has_blank_line
     }
 
     /// Returns the text range of token at the given index

--- a/crates/pgls_lexer/src/lexer.rs
+++ b/crates/pgls_lexer/src/lexer.rs
@@ -12,6 +12,7 @@ pub struct Lexer<'a> {
     offset: usize,
     /// we store line ending counts outside of SyntaxKind because of the u16 represenation of SyntaxKind
     line_ending_counts: Vec<usize>,
+    has_blank_line: bool,
 }
 
 impl<'a> Lexer<'a> {
@@ -24,6 +25,7 @@ impl<'a> Lexer<'a> {
             error: Vec::new(),
             offset: 0,
             line_ending_counts: Vec::new(),
+            has_blank_line: false,
         }
     }
 
@@ -43,6 +45,7 @@ impl<'a> Lexer<'a> {
             start: self.start,
             error: self.error,
             line_ending_counts: self.line_ending_counts,
+            has_blank_line: self.has_blank_line,
         }
     }
 
@@ -63,6 +66,8 @@ impl<'a> Lexer<'a> {
         );
 
         self.line_ending_counts.push(line_ending_count.unwrap_or(0));
+        self.has_blank_line |=
+            kind == SyntaxKind::LINE_ENDING && line_ending_count.is_some_and(|count| count >= 2);
 
         if let Some(err) = err {
             let token = (self.kind.len() - 1) as u32;

--- a/crates/pgls_lexer/src/lib.rs
+++ b/crates/pgls_lexer/src/lib.rs
@@ -1,10 +1,12 @@
 mod codegen;
 mod lexed;
 mod lexer;
+mod params;
 
 pub use crate::codegen::syntax_kind::SyntaxKind;
 pub use crate::lexed::{LexDiagnostic, Lexed};
 pub use crate::lexer::Lexer;
+pub use crate::params::convert_to_positional_params;
 
 /// Lex the input string into tokens and diagnostics
 pub fn lex(input: &str) -> Lexed<'_> {

--- a/crates/pgls_lexer/src/lib.rs
+++ b/crates/pgls_lexer/src/lib.rs
@@ -108,6 +108,13 @@ mod tests {
         let lexed = lex(input);
         assert_eq!(lexed.len(), 1);
         assert_eq!(lexed.kind(0), SyntaxKind::EOF);
+        assert!(!lexed.has_blank_line());
+    }
+
+    #[test]
+    fn test_blank_line_detection() {
+        assert!(!lex("SELECT 1\nSELECT 2").has_blank_line());
+        assert!(lex("SELECT 1\n\nSELECT 2").has_blank_line());
     }
 
     #[test]

--- a/crates/pgls_lexer/src/params.rs
+++ b/crates/pgls_lexer/src/params.rs
@@ -1,0 +1,138 @@
+use std::collections::HashMap;
+
+use crate::{SyntaxKind, lex};
+
+// Keywords that, when preceding a named parameter, indicate that the parameter should be treated
+// as an identifier rather than a positional parameter.
+const IDENTIFIER_CONTEXT: [SyntaxKind; 15] = [
+    SyntaxKind::TO_KW,
+    SyntaxKind::FROM_KW,
+    SyntaxKind::SCHEMA_KW,
+    SyntaxKind::TABLE_KW,
+    SyntaxKind::INDEX_KW,
+    SyntaxKind::CONSTRAINT_KW,
+    SyntaxKind::OWNER_KW,
+    SyntaxKind::ROLE_KW,
+    SyntaxKind::USER_KW,
+    SyntaxKind::DATABASE_KW,
+    SyntaxKind::TYPE_KW,
+    SyntaxKind::CAST_KW,
+    SyntaxKind::ALTER_KW,
+    SyntaxKind::DROP_KW,
+    // for schema.table style identifiers
+    SyntaxKind::DOT,
+];
+
+/// Converts named parameters in a SQL query string to positional parameters.
+///
+/// This function scans the input SQL string for named parameters (e.g., `@param`, `:param`, `:'param'`)
+/// and replaces them with positional parameters (e.g., `$1`, `$2`, etc.).
+///
+/// It maintains the original spacing of the named parameters in the output string.
+///
+/// Useful for preparing SQL queries for parsing or execution where named paramters are not supported.
+pub fn convert_to_positional_params(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut param_mapping: HashMap<&str, usize> = HashMap::new();
+    let mut param_index = 1;
+
+    let lexed = lex(text);
+    for (token_idx, kind) in lexed.tokens().enumerate() {
+        if kind == SyntaxKind::EOF {
+            break;
+        }
+
+        let token_text = lexed.text(token_idx);
+
+        if matches!(kind, SyntaxKind::NAMED_PARAM) {
+            let idx = match param_mapping.get(token_text) {
+                Some(&index) => index,
+                None => {
+                    let index = param_index;
+                    param_mapping.insert(token_text, index);
+                    param_index += 1;
+                    index
+                }
+            };
+
+            // find previous non-trivia token
+            let prev_token = (0..token_idx)
+                .rev()
+                .map(|i| lexed.kind(i))
+                .find(|kind| !kind.is_trivia());
+
+            let replacement = match prev_token {
+                Some(k) if IDENTIFIER_CONTEXT.contains(&k) => deterministic_identifier(idx - 1),
+                _ => format!("${idx}"),
+            };
+            let original_len = token_text.len();
+            let replacement_len = replacement.len();
+
+            result.push_str(&replacement);
+
+            // maintain original spacing
+            if replacement_len < original_len {
+                result.push_str(&" ".repeat(original_len - replacement_len));
+            }
+        } else {
+            result.push_str(token_text);
+        }
+    }
+
+    result
+}
+
+const ALPHABET: [char; 26] = [
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+    't', 'u', 'v', 'w', 'x', 'y', 'z',
+];
+
+/// Generates a deterministic identifier based on the given index.
+fn deterministic_identifier(idx: usize) -> String {
+    let iteration = idx / ALPHABET.len();
+    let pos = idx % ALPHABET.len();
+
+    format!(
+        "{}{}",
+        ALPHABET[pos],
+        if iteration > 0 {
+            deterministic_identifier(iteration - 1)
+        } else {
+            "".to_string()
+        }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deterministic_identifier() {
+        assert_eq!(deterministic_identifier(0), "a");
+        assert_eq!(deterministic_identifier(25), "z");
+        assert_eq!(deterministic_identifier(26), "aa");
+        assert_eq!(deterministic_identifier(27), "ba");
+        assert_eq!(deterministic_identifier(51), "za");
+    }
+
+    #[test]
+    fn test_convert_to_positional_params() {
+        let input = "select * from users where id = @one and name = :two and email = :'three';";
+        let result = convert_to_positional_params(input);
+        assert_eq!(
+            result,
+            "select * from users where id = $1   and name = $2   and email = $3      ;"
+        );
+    }
+
+    #[test]
+    fn test_convert_to_positional_params_with_duplicates() {
+        let input = "select * from users where first_name = @one and starts_with(email, @one) and created_at > @two;";
+        let result = convert_to_positional_params(input);
+        assert_eq!(
+            result,
+            "select * from users where first_name = $1   and starts_with(email, $1  ) and created_at > $2  ;"
+        );
+    }
+}

--- a/crates/pgls_statement_splitter/benches/splitter.rs
+++ b/crates/pgls_statement_splitter/benches/splitter.rs
@@ -70,6 +70,34 @@ where
         },
     );
 
+    // A statement whose blank lines sit *inside* it, so that the parse check
+    // actually runs. The cases above only have blank lines between statements,
+    // which the splitter skips without asking PostgreSQL anything.
+    let blank_line_statement = r#"select
+  t.a,
+  t.b
+
+from t
+
+left join u on u.a = t.a
+
+where t.a > 0;
+
+"#;
+
+    let blank_line_content = blank_line_statement.repeat(500);
+
+    c.bench_function(
+        format!(
+            "statement with inner blank lines, length {}",
+            blank_line_content.len()
+        )
+        .as_str(),
+        |b| {
+            b.iter(|| black_box(split(&blank_line_content)));
+        },
+    );
+
     let small_statement = r#"select 1 from public.user where id = 1"#;
     let small_content = small_statement.repeat(500);
 

--- a/crates/pgls_statement_splitter/src/lib.rs
+++ b/crates/pgls_statement_splitter/src/lib.rs
@@ -17,7 +17,7 @@ pub struct SplitResult {
 pub fn split(sql: &str) -> SplitResult {
     let lexed = Lexer::new(sql).lex();
 
-    let mut splitter = Splitter::new(&lexed);
+    let mut splitter = Splitter::with_blank_line_boundaries(&lexed);
 
     let _ = source(&mut splitter);
 

--- a/crates/pgls_statement_splitter/src/lib.rs
+++ b/crates/pgls_statement_splitter/src/lib.rs
@@ -5,37 +5,140 @@ pub mod diagnostics;
 mod splitter;
 
 use diagnostics::SplitDiagnostic;
-use pgls_lexer::Lexer;
+use pgls_lexer::{Lexed, Lexer, convert_to_positional_params};
 use pgls_text_size::TextRange;
-use splitter::{Splitter, source};
+use splitter::{SplitResult as PassResult, Splitter, source};
 
 pub struct SplitResult {
     pub ranges: Vec<TextRange>,
     pub errors: Vec<SplitDiagnostic>,
 }
 
+/// Splits `sql` into the ranges of the statements it contains.
+///
+/// Statements are delimited by `;` and by the statement starts the splitter
+/// knows about. A blank line is *not* a statement boundary, unless splitting on
+/// it is the only reading that makes sense: either the fragment does not parse
+/// as a whole, or it does but splitting it yields several statements that are
+/// each valid on their own — which is what a missing `;` looks like.
+///
+/// That keeps error recovery working while typing, without cutting valid SQL in
+/// two just because it is formatted across a blank line.
 pub fn split(sql: &str) -> SplitResult {
     let lexed = Lexer::new(sql).lex();
+    let coarse = split_pass(&lexed, false);
 
-    let mut splitter = Splitter::with_blank_line_boundaries(&lexed);
+    // Resolved to text ranges up front so each one can be attributed to the
+    // fragment that contains it. There is normally none at all.
+    let coarse_errors: Vec<(TextRange, String)> = coarse
+        .errors
+        .into_iter()
+        .map(|err| (lexed.range(err.token), err.msg))
+        .collect();
+
+    let mut ranges = Vec::with_capacity(coarse.ranges.len());
+    let mut errors: Vec<SplitDiagnostic> = lexed.errors().into_iter().map(Into::into).collect();
+
+    for range in coarse.ranges {
+        // The two passes differ only in how they treat a blank line, so a
+        // fragment without one would come back from the recovery pass
+        // byte-identical, errors included. Nothing to ask PostgreSQL about.
+        if !contains_blank_line(&sql[range]) {
+            ranges.push(range);
+            errors.extend(
+                coarse_errors
+                    .iter()
+                    .filter(|(span, _)| range.contains_range(*span))
+                    .map(|(span, msg)| SplitDiagnostic::new(msg.clone(), *span)),
+            );
+            continue;
+        }
+
+        // Recovery pass: re-split this fragment on its own, this time treating
+        // blank lines as statement boundaries. Its lexing errors are ignored;
+        // the whole-source lex above already reported them.
+        let offset = range.start();
+        let fragment = Lexer::new(&sql[range]).lex();
+        let recovered = split_pass(&fragment, true);
+
+        if parses(&sql[range]) && !splits_into_valid_statements(&sql[range], &recovered.ranges) {
+            // PostgreSQL is happy with the fragment as a whole, so any splitter
+            // complaint about it was a false positive. Drop it with the blank line.
+            ranges.push(range);
+            continue;
+        }
+
+        ranges.extend(recovered.ranges.into_iter().map(|r| r + offset));
+        errors.extend(
+            recovered
+                .errors
+                .into_iter()
+                .map(|err| SplitDiagnostic::new(err.msg, fragment.range(err.token) + offset)),
+        );
+    }
+
+    SplitResult { ranges, errors }
+}
+
+fn split_pass(lexed: &Lexed, blank_line_is_boundary: bool) -> PassResult {
+    let mut splitter = if blank_line_is_boundary {
+        Splitter::with_blank_line_boundaries(lexed)
+    } else {
+        Splitter::new(lexed)
+    };
 
     let _ = source(&mut splitter);
 
-    let split_result = splitter.finish();
+    splitter.finish()
+}
 
-    let mut errors: Vec<SplitDiagnostic> = lexed.errors().into_iter().map(Into::into).collect();
+/// Whether PostgreSQL can parse `fragment`.
+///
+/// Named parameters are normalized to positional ones first: libpg_query reads
+/// `$id` as an unterminated dollar-quote and rejects it, so the workspace
+/// applies the same normalization before parsing.
+///
+/// `split_with_parser` runs the raw parser without deserializing the protobuf
+/// AST, which is all that is needed to answer this question.
+fn parses(fragment: &str) -> bool {
+    let normalized = convert_to_positional_params(fragment);
+    pgls_query::split_with_parser(&normalized).is_ok()
+}
 
-    errors.extend(
-        split_result
-            .errors
-            .into_iter()
-            .map(|err| SplitDiagnostic::from_split_error(err, &lexed)),
-    );
+/// Whether splitting `fragment` on its blank lines yields more than one piece,
+/// each a valid statement on its own.
+///
+/// This is what a missing `;` between two statements looks like. Without the
+/// check, `SELECT ... FROM t` followed by a blank line and `BEGIN;` would be
+/// kept whole, because PostgreSQL happily reads `BEGIN` as a table alias.
+fn splits_into_valid_statements(fragment: &str, pieces: &[TextRange]) -> bool {
+    pieces.len() > 1 && pieces.iter().all(|piece| parses(&fragment[*piece]))
+}
 
-    SplitResult {
-        ranges: split_result.ranges,
-        errors,
+/// Whether `s` contains a blank line: two line endings separated only by
+/// horizontal whitespace.
+///
+/// This is a plain text scan, so it also matches blank lines inside string
+/// literals and comments, and it is looser than the splitter's own rule, which
+/// requires consecutive line endings within a single token. Both differences
+/// err the same way: an unnecessary parse, never an incorrect split.
+fn contains_blank_line(s: &str) -> bool {
+    let mut after_line_ending = false;
+
+    for byte in s.bytes() {
+        match byte {
+            b'\n' => {
+                if after_line_ending {
+                    return true;
+                }
+                after_line_ending = true;
+            }
+            b'\r' | b' ' | b'\t' | 0x0b | 0x0c => {}
+            _ => after_line_ending = false,
+        }
     }
+
+    false
 }
 
 #[cfg(test)]
@@ -824,5 +927,79 @@ VALUES
     fn backslash_commands_surrounding_statements() {
         Tester::from("\\dt\nselect 1;\n\\du\nselect 2;\n\\dn")
             .expect_statements(vec!["select 1;", "select 2;"]);
+    }
+
+    // --- Blank lines inside a statement (issue #784) --------------------------
+
+    /// A blank line inside a FROM clause is not a statement boundary.
+    #[test]
+    fn blank_line_inside_from() {
+        Tester::from("SELECT\n\tt.a\nFROM t\n\nLEFT JOIN u ON u.a = t.a;")
+            .assert_single_statement()
+            .assert_no_errors();
+    }
+
+    #[test]
+    fn blank_line_after_last_cte() {
+        Tester::from("with a as (select 1)\n\nselect * from a;")
+            .assert_single_statement()
+            .assert_no_errors();
+    }
+
+    #[test]
+    fn blank_line_between_ctes() {
+        Tester::from("with a as (select 1),\n\nb as (select 2)\n\nselect * from a, b;")
+            .assert_single_statement()
+            .assert_no_errors();
+    }
+
+    /// The recovery pass still splits on blank lines when the fragment cannot
+    /// be parsed, which is what keeps error recovery usable in the editor.
+    #[test]
+    fn blank_line_in_unparsable_sql_still_splits() {
+        Tester::from("random stuff\n\nmore randomness\n\nselect 3").expect_statements(vec![
+            "random stuff",
+            "more randomness",
+            "select 3",
+        ]);
+    }
+
+    /// A blank line inside a string literal is not a boundary either.
+    #[test]
+    fn blank_line_in_string_literal() {
+        Tester::from("select '\n\n' from t;")
+            .assert_single_statement()
+            .assert_no_errors();
+    }
+
+    /// libpg_query rejects named parameters, so the parse check normalizes them
+    /// the same way the workspace does before parsing.
+    #[test]
+    fn blank_line_with_named_param() {
+        Tester::from("select id\nfrom t\n\nwhere id = $some_id;")
+            .assert_single_statement()
+            .assert_no_errors();
+    }
+
+    #[test]
+    fn semicolon_in_comment_and_dollar_quote() {
+        Tester::from("select /*;*/ 1;\nselect $$;$$;")
+            .expect_statements(vec!["select /*;*/ 1;", "select $$;$$;"])
+            .assert_no_errors();
+    }
+
+    /// A missing `;` must not let the next statement be swallowed as an alias:
+    /// `FROM lotest_stash_values BEGIN` parses, `BEGIN` being an unreserved
+    /// keyword, so the blank line is the only thing telling them apart.
+    #[test]
+    fn blank_line_splits_when_both_halves_are_valid_statements() {
+        Tester::from("SELECT a FROM t\n\nBEGIN;")
+            .expect_statements(vec!["SELECT a FROM t", "BEGIN;"]);
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(split("").ranges.len(), 0);
+        assert_eq!(split("   \n  \n ").ranges.len(), 0);
     }
 }

--- a/crates/pgls_statement_splitter/src/lib.rs
+++ b/crates/pgls_statement_splitter/src/lib.rs
@@ -5,7 +5,7 @@ pub mod diagnostics;
 mod splitter;
 
 use diagnostics::SplitDiagnostic;
-use pgls_lexer::{Lexed, Lexer, convert_to_positional_params};
+use pgls_lexer::{Lexed, Lexer, SyntaxKind, convert_to_positional_params};
 use pgls_text_size::TextRange;
 use splitter::{SplitResult as PassResult, Splitter, source};
 
@@ -35,15 +35,34 @@ pub fn split(sql: &str) -> SplitResult {
         .into_iter()
         .map(|err| (lexed.range(err.token), err.msg))
         .collect();
+    let mut blank_lines = lexed.has_blank_line().then(|| {
+        (0..lexed.len().saturating_sub(1))
+            .filter(|&idx| {
+                lexed.kind(idx) == SyntaxKind::LINE_ENDING && lexed.line_ending_count(idx) >= 2
+            })
+            .map(|idx| lexed.range(idx))
+            .peekable()
+    });
 
     let mut ranges = Vec::with_capacity(coarse.ranges.len());
     let mut errors: Vec<SplitDiagnostic> = lexed.errors().into_iter().map(Into::into).collect();
 
     for range in coarse.ranges {
+        let contains_blank_line = blank_lines.as_mut().is_some_and(|blank_lines| {
+            while blank_lines
+                .next_if(|blank_line| blank_line.end() <= range.start())
+                .is_some()
+            {}
+
+            blank_lines
+                .peek()
+                .is_some_and(|blank_line| range.contains_range(*blank_line))
+        });
+
         // The two passes differ only in how they treat a blank line, so a
         // fragment without one would come back from the recovery pass
         // byte-identical, errors included. Nothing to ask PostgreSQL about.
-        if !contains_blank_line(&sql[range]) {
+        if !contains_blank_line {
             ranges.push(range);
             errors.extend(
                 coarse_errors
@@ -113,32 +132,6 @@ fn parses(fragment: &str) -> bool {
 /// kept whole, because PostgreSQL happily reads `BEGIN` as a table alias.
 fn splits_into_valid_statements(fragment: &str, pieces: &[TextRange]) -> bool {
     pieces.len() > 1 && pieces.iter().all(|piece| parses(&fragment[*piece]))
-}
-
-/// Whether `s` contains a blank line: two line endings separated only by
-/// horizontal whitespace.
-///
-/// This is a plain text scan, so it also matches blank lines inside string
-/// literals and comments, and it is looser than the splitter's own rule, which
-/// requires consecutive line endings within a single token. Both differences
-/// err the same way: an unnecessary parse, never an incorrect split.
-fn contains_blank_line(s: &str) -> bool {
-    let mut after_line_ending = false;
-
-    for byte in s.bytes() {
-        match byte {
-            b'\n' => {
-                if after_line_ending {
-                    return true;
-                }
-                after_line_ending = true;
-            }
-            b'\r' | b' ' | b'\t' | 0x0b | 0x0c => {}
-            _ => after_line_ending = false,
-        }
-    }
-
-    false
 }
 
 #[cfg(test)]

--- a/crates/pgls_statement_splitter/src/splitter.rs
+++ b/crates/pgls_statement_splitter/src/splitter.rs
@@ -38,16 +38,34 @@ pub struct Splitter<'a> {
     stmt_ranges: Vec<(usize, usize)>,
     errors: Vec<SplitError>,
     current_stmt_start: Option<usize>,
+    /// Whether a blank line terminates the current statement.
+    blank_line_is_boundary: bool,
 }
 
 impl<'a> Splitter<'a> {
+    /// Splits on `;` and on structural statement starts only. A blank line is
+    /// not a statement boundary.
+    // Unused until split() grows its coarse pass in the next commit.
+    #[allow(dead_code)]
     pub fn new(lexed: &'a Lexed<'a>) -> Self {
+        Self::with_options(lexed, false)
+    }
+
+    /// Additionally treats a blank line as a statement boundary. Used as a
+    /// recovery pass on fragments PostgreSQL cannot parse, where there is no
+    /// better signal to resynchronize on.
+    pub fn with_blank_line_boundaries(lexed: &'a Lexed<'a>) -> Self {
+        Self::with_options(lexed, true)
+    }
+
+    fn with_options(lexed: &'a Lexed<'a>, blank_line_is_boundary: bool) -> Self {
         Self {
             lexed,
             current_pos: 0,
             stmt_ranges: Vec::new(),
             errors: Vec::new(),
             current_stmt_start: None,
+            blank_line_is_boundary,
         }
     }
 
@@ -178,7 +196,9 @@ impl<'a> Splitter<'a> {
     fn is_trivia(&self, idx: usize) -> bool {
         match self.lexed.kind(idx) {
             k if TRIVIA_TOKENS.contains(&k) => true,
-            SyntaxKind::LINE_ENDING => self.lexed.line_ending_count(idx) < 2,
+            SyntaxKind::LINE_ENDING => {
+                !self.blank_line_is_boundary || self.lexed.line_ending_count(idx) < 2
+            }
             _ => false,
         }
     }

--- a/crates/pgls_statement_splitter/src/splitter.rs
+++ b/crates/pgls_statement_splitter/src/splitter.rs
@@ -45,8 +45,6 @@ pub struct Splitter<'a> {
 impl<'a> Splitter<'a> {
     /// Splits on `;` and on structural statement starts only. A blank line is
     /// not a statement boundary.
-    // Unused until split() grows its coarse pass in the next commit.
-    #[allow(dead_code)]
     pub fn new(lexed: &'a Lexed<'a>) -> Self {
         Self::with_options(lexed, false)
     }

--- a/crates/pgls_statement_splitter/tests/data/blank_line_in_from__1.sql
+++ b/crates/pgls_statement_splitter/tests/data/blank_line_in_from__1.sql
@@ -1,0 +1,5 @@
+SELECT
+	t.a
+FROM t
+
+LEFT JOIN u ON u.a = t.a;

--- a/crates/pgls_workspace/src/workspace/server/pg_query.rs
+++ b/crates/pgls_workspace/src/workspace/server/pg_query.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, LazyLock, Mutex};
 
 use lru::LruCache;
-use pgls_lexer::lex;
+pub use pgls_lexer::convert_to_positional_params;
 use pgls_query_ext::diagnostics::*;
 use pgls_text_size::TextRange;
 use regex::Regex;
@@ -104,139 +103,9 @@ fn is_composite_type_error(err: &str) -> bool {
     COMPOSITE_TYPE_ERROR_RE.is_match(err)
 }
 
-// Keywords that, when preceding a named parameter, indicate that the parameter should be treated
-// as an identifier rather than a positional parameter.
-const IDENTIFIER_CONTEXT: [pgls_lexer::SyntaxKind; 15] = [
-    pgls_lexer::SyntaxKind::TO_KW,
-    pgls_lexer::SyntaxKind::FROM_KW,
-    pgls_lexer::SyntaxKind::SCHEMA_KW,
-    pgls_lexer::SyntaxKind::TABLE_KW,
-    pgls_lexer::SyntaxKind::INDEX_KW,
-    pgls_lexer::SyntaxKind::CONSTRAINT_KW,
-    pgls_lexer::SyntaxKind::OWNER_KW,
-    pgls_lexer::SyntaxKind::ROLE_KW,
-    pgls_lexer::SyntaxKind::USER_KW,
-    pgls_lexer::SyntaxKind::DATABASE_KW,
-    pgls_lexer::SyntaxKind::TYPE_KW,
-    pgls_lexer::SyntaxKind::CAST_KW,
-    pgls_lexer::SyntaxKind::ALTER_KW,
-    pgls_lexer::SyntaxKind::DROP_KW,
-    // for schema.table style identifiers
-    pgls_lexer::SyntaxKind::DOT,
-];
-
-/// Converts named parameters in a SQL query string to positional parameters.
-///
-/// This function scans the input SQL string for named parameters (e.g., `@param`, `:param`, `:'param'`)
-/// and replaces them with positional parameters (e.g., `$1`, `$2`, etc.).
-///
-/// It maintains the original spacing of the named parameters in the output string.
-///
-/// Useful for preparing SQL queries for parsing or execution where named paramters are not supported.
-pub fn convert_to_positional_params(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut param_mapping: HashMap<&str, usize> = HashMap::new();
-    let mut param_index = 1;
-
-    let lexed = lex(text);
-    for (token_idx, kind) in lexed.tokens().enumerate() {
-        if kind == pgls_lexer::SyntaxKind::EOF {
-            break;
-        }
-
-        let token_text = lexed.text(token_idx);
-
-        if matches!(kind, pgls_lexer::SyntaxKind::NAMED_PARAM) {
-            let idx = match param_mapping.get(token_text) {
-                Some(&index) => index,
-                None => {
-                    let index = param_index;
-                    param_mapping.insert(token_text, index);
-                    param_index += 1;
-                    index
-                }
-            };
-
-            // find previous non-trivia token
-            let prev_token = (0..token_idx)
-                .rev()
-                .map(|i| lexed.kind(i))
-                .find(|kind| !kind.is_trivia());
-
-            let replacement = match prev_token {
-                Some(k) if IDENTIFIER_CONTEXT.contains(&k) => deterministic_identifier(idx - 1),
-                _ => format!("${idx}"),
-            };
-            let original_len = token_text.len();
-            let replacement_len = replacement.len();
-
-            result.push_str(&replacement);
-
-            // maintain original spacing
-            if replacement_len < original_len {
-                result.push_str(&" ".repeat(original_len - replacement_len));
-            }
-        } else {
-            result.push_str(token_text);
-        }
-    }
-
-    result
-}
-
-const ALPHABET: [char; 26] = [
-    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
-    't', 'u', 'v', 'w', 'x', 'y', 'z',
-];
-
-/// Generates a deterministic identifier based on the given index.
-fn deterministic_identifier(idx: usize) -> String {
-    let iteration = idx / ALPHABET.len();
-    let pos = idx % ALPHABET.len();
-
-    format!(
-        "{}{}",
-        ALPHABET[pos],
-        if iteration > 0 {
-            deterministic_identifier(iteration - 1)
-        } else {
-            "".to_string()
-        }
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_deterministic_identifier() {
-        assert_eq!(deterministic_identifier(0), "a");
-        assert_eq!(deterministic_identifier(25), "z");
-        assert_eq!(deterministic_identifier(26), "aa");
-        assert_eq!(deterministic_identifier(27), "ba");
-        assert_eq!(deterministic_identifier(51), "za");
-    }
-
-    #[test]
-    fn test_convert_to_positional_params() {
-        let input = "select * from users where id = @one and name = :two and email = :'three';";
-        let result = convert_to_positional_params(input);
-        assert_eq!(
-            result,
-            "select * from users where id = $1   and name = $2   and email = $3      ;"
-        );
-    }
-
-    #[test]
-    fn test_convert_to_positional_params_with_duplicates() {
-        let input = "select * from users where first_name = @one and starts_with(email, @one) and created_at > @two;";
-        let result = convert_to_positional_params(input);
-        assert_eq!(
-            result,
-            "select * from users where first_name = $1   and starts_with(email, $1  ) and created_at > $2  ;"
-        );
-    }
 
     #[test]
     fn test_positional_params_in_grant() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The statement splitter treats blank lines as statement boundaries. Valid SQL formatted
with blank lines can therefore be split into invalid fragments and reported as syntax
errors.

Fixes #784.

This also addresses the underlying behavior reported in #372, #380, and #780.

## What is the new behavior?

Statement splitting now uses two passes:

1. A coarse pass splits on `;` and structural statement starts while ignoring blank lines.
2. For fragments containing blank lines, a recovery pass checks whether PostgreSQL can
   parse the fragment:
   - parsable fragments remain intact;
   - unparsable fragments are re-split using blank lines as boundaries.

A blank line now splits SQL only when the complete fragment cannot be parsed.

This preserves recovery for incomplete SQL while typing, including cases such as a
missing `;` before `BEGIN`.

## Additional context

- Named parameters are normalized before the parser check, matching workspace parsing.
- The lexer records whether the source contains blank lines, so files without them avoid
  the recovery-path token scan.
- Valid fragments can still be split when their blank-line-separated parts are independently
  valid statements.

Added coverage for:

- blank lines inside a `FROM` clause;
- blank lines between CTEs and after the final CTE;
- blank lines inside string literals;
- named parameters;
- parser recovery for invalid SQL;
- a missing semicolon before `BEGIN`.

Validated with:

```text
cargo test -p pgls_lexer -p pgls_statement_splitter
cargo clippy --all-targets --all-features -- -D warnings