### PR TITLE
feat(typecheck): typecheck CREATE … AS query bodies

### DIFF
--- a/crates/pgls_typecheck/src/diagnostics.rs
+++ b/crates/pgls_typecheck/src/diagnostics.rs
@@ -153,6 +153,7 @@ pub(crate) fn create_type_error(
     pg_err: &PgDatabaseError,
     ts: &tree_sitter::Tree,
     typed_replacement: TypedReplacement,
+    source_offset: TextSize,
 ) -> TypecheckDiagnostic {
     let position = pg_err.position().and_then(|pos| match pos {
         sqlx::postgres::PgErrorPosition::Original(pos) => Some(pos - 1),
@@ -171,9 +172,24 @@ pub(crate) fn create_type_error(
         ts.root_node()
             .named_descendant_for_byte_range(pos.into(), pos.into())
             .map(|node| {
+                let node = if source_offset == TextSize::from(0) {
+                    node
+                } else {
+                    node.parent()
+                        .filter(|parent| parent.kind() == "object_reference")
+                        .and_then(|parent| {
+                            let mut cursor = parent.walk();
+                            parent
+                                .children(&mut cursor)
+                                .filter(|child| child.is_named())
+                                .last()
+                        })
+                        .unwrap_or(node)
+                };
+
                 TextRange::new(
-                    node.start_byte().try_into().unwrap(),
-                    node.end_byte().try_into().unwrap(),
+                    TextSize::from(u32::try_from(node.start_byte()).unwrap()) + source_offset,
+                    TextSize::from(u32::try_from(node.end_byte()).unwrap()) + source_offset,
                 )
             })
     });

--- a/crates/pgls_typecheck/src/lib.rs
+++ b/crates/pgls_typecheck/src/lib.rs
@@ -6,6 +6,7 @@ use diagnostics::create_type_error;
 use globset::Glob;
 use itertools::Itertools;
 use pgls_schema_cache::SchemaCache;
+use pgls_text_size::TextSize;
 use sqlx::postgres::PgDatabaseError;
 pub use sqlx::postgres::PgSeverity;
 use sqlx::{Executor, PgPool};
@@ -28,17 +29,25 @@ pub struct TypecheckParams<'a> {
 pub async fn check_sql(
     params: TypecheckParams<'_>,
 ) -> Result<Option<TypecheckDiagnostic>, sqlx::Error> {
-    // Check if the AST is not a supported statement type
-    if !matches!(
-        params.ast,
-        pgls_query::NodeEnum::SelectStmt(_)
-            | pgls_query::NodeEnum::InsertStmt(_)
-            | pgls_query::NodeEnum::UpdateStmt(_)
-            | pgls_query::NodeEnum::DeleteStmt(_)
-            | pgls_query::NodeEnum::CommonTableExpr(_)
-    ) {
+    let Some(target) = typecheck_target(params.ast, params.tree, params.sql) else {
         return Ok(None);
-    }
+    };
+
+    let mut parser = tree_sitter::Parser::new();
+    let inner_tree;
+    let (sql, tree, source_offset) = match target {
+        TypecheckTarget::Direct => (params.sql, params.tree, TextSize::from(0)),
+        TypecheckTarget::CreateQuery { sql, source_offset } => {
+            parser
+                .set_language(&pgls_treesitter_grammar::LANGUAGE.into())
+                .expect("Error loading sql language");
+            let Some(tree) = parser.parse(sql, None) else {
+                return Ok(None);
+            };
+            inner_tree = tree;
+            (sql, &inner_tree, source_offset)
+        }
+    };
 
     let mut conn = params.conn.acquire().await?;
 
@@ -48,12 +57,7 @@ pub async fn check_sql(
     // each typecheck operation.
     conn.close_on_drop();
 
-    let typed_replacement = apply_identifiers(
-        params.identifiers,
-        params.schema_cache,
-        params.tree,
-        params.sql,
-    );
+    let typed_replacement = apply_identifiers(params.identifiers, params.schema_cache, tree, sql);
 
     let mut search_path_schemas =
         get_schemas_in_search_path(params.schema_cache, params.search_path_patterns);
@@ -78,12 +82,57 @@ pub async fn check_sql(
             let pg_err = err.downcast_ref::<PgDatabaseError>();
             Ok(Some(create_type_error(
                 pg_err,
-                params.tree,
+                tree,
                 typed_replacement,
+                source_offset,
             )))
         }
         Err(err) => Err(err),
     }
+}
+
+enum TypecheckTarget<'a> {
+    Direct,
+    CreateQuery {
+        sql: &'a str,
+        source_offset: TextSize,
+    },
+}
+
+fn typecheck_target<'a>(
+    ast: &pgls_query::NodeEnum,
+    tree: &tree_sitter::Tree,
+    sql: &'a str,
+) -> Option<TypecheckTarget<'a>> {
+    match ast {
+        pgls_query::NodeEnum::SelectStmt(_)
+        | pgls_query::NodeEnum::InsertStmt(_)
+        | pgls_query::NodeEnum::UpdateStmt(_)
+        | pgls_query::NodeEnum::DeleteStmt(_)
+        | pgls_query::NodeEnum::CommonTableExpr(_) => Some(TypecheckTarget::Direct),
+        pgls_query::NodeEnum::CreateTableAsStmt(_) | pgls_query::NodeEnum::ViewStmt(_) => {
+            let node = find_create_query(tree.root_node())?;
+            if node.has_error() {
+                return None;
+            }
+            let start = node.start_byte();
+            let end = node.end_byte();
+            Some(TypecheckTarget::CreateQuery {
+                sql: sql.get(start..end)?,
+                source_offset: TextSize::try_from(start).ok()?,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn find_create_query(node: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
+    if node.kind() == "create_query" {
+        return Some(node);
+    }
+
+    let mut cursor = node.walk();
+    node.children(&mut cursor).find_map(find_create_query)
 }
 
 fn get_schemas_in_search_path(schema_cache: &SchemaCache, glob_patterns: Vec<String>) -> Vec<&str> {
@@ -114,4 +163,67 @@ fn get_schemas_in_search_path(schema_cache: &SchemaCache, glob_patterns: Vec<Str
         .flatten()
         .unique()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(sql: &str) -> Option<(String, TextSize)> {
+        let ast = pgls_query::parse(sql).ok()?.into_root()?;
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&pgls_treesitter_grammar::LANGUAGE.into())
+            .ok()?;
+        let tree = parser.parse(sql, None)?;
+
+        match typecheck_target(&ast, &tree, sql)? {
+            TypecheckTarget::Direct => Some((sql.to_string(), TextSize::from(0))),
+            TypecheckTarget::CreateQuery { sql, source_offset } => {
+                Some((sql.to_string(), source_offset))
+            }
+        }
+    }
+
+    #[test]
+    fn extracts_create_query_targets() {
+        let cases = [
+            (
+                "CREATE TABLE t2 AS SELECT t.a FROM t",
+                "SELECT t.a FROM t",
+                19,
+            ),
+            (
+                "CREATE MATERIALIZED VIEW mv1 AS SELECT t.a FROM t",
+                "SELECT t.a FROM t",
+                32,
+            ),
+            (
+                "CREATE VIEW v1 AS SELECT t.a FROM t",
+                "SELECT t.a FROM t",
+                18,
+            ),
+            (
+                "CREATE OR REPLACE VIEW v1 AS\n  SELECT t.a\n  FROM t",
+                "SELECT t.a\n  FROM t",
+                31,
+            ),
+        ];
+
+        for (input, expected_sql, expected_offset) in cases {
+            assert_eq!(
+                target(input),
+                Some((expected_sql.to_string(), TextSize::from(expected_offset)))
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_unsupported_typecheck_targets() {
+        assert_eq!(target("CREATE TABLE t (id INT)"), None);
+        assert_eq!(
+            target("SELECT id FROM t"),
+            Some(("SELECT id FROM t".to_string(), TextSize::from(0)))
+        );
+    }
 }

--- a/crates/pgls_typecheck/tests/diagnostics.rs
+++ b/crates/pgls_typecheck/tests/diagnostics.rs
@@ -187,6 +187,100 @@ async fn invalid_column(test_db: PgPool) {
 }
 
 #[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
+async fn create_table_as_invalid_column(test_db: PgPool) {
+    TestSetup {
+        name: "create_table_as_invalid_column",
+        query: "CREATE TABLE t2 AS SELECT t.nope FROM t;",
+        setup: Some("CREATE TABLE t (a INT);"),
+        test_db: &test_db,
+        typed_identifiers: vec![],
+    }
+    .test()
+    .await;
+}
+
+#[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
+async fn create_table_as_invalid_relation(test_db: PgPool) {
+    TestSetup {
+        name: "create_table_as_invalid_relation",
+        query: "CREATE TABLE t3 AS SELECT t.a FROM nonexistent_table AS t;",
+        setup: Some("CREATE TABLE t (a INT);"),
+        test_db: &test_db,
+        typed_identifiers: vec![],
+    }
+    .test()
+    .await;
+}
+
+#[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
+async fn create_materialized_view_as_invalid_column(test_db: PgPool) {
+    TestSetup {
+        name: "create_materialized_view_as_invalid_column",
+        query: "CREATE MATERIALIZED VIEW mv1 AS SELECT t.nope FROM t;",
+        setup: Some("CREATE TABLE t (a INT);"),
+        test_db: &test_db,
+        typed_identifiers: vec![],
+    }
+    .test()
+    .await;
+}
+
+#[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
+async fn create_view_as_invalid_column(test_db: PgPool) {
+    TestSetup {
+        name: "create_view_as_invalid_column",
+        query: "CREATE VIEW v1 AS SELECT t.nope FROM t;",
+        setup: Some("CREATE TABLE t (a INT);"),
+        test_db: &test_db,
+        typed_identifiers: vec![],
+    }
+    .test()
+    .await;
+}
+
+#[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
+async fn create_as_valid_queries_do_not_execute_ddl(test_db: PgPool) {
+    test_db
+        .execute("CREATE TABLE t (a INT);")
+        .await
+        .expect("Failed to create test table");
+
+    for (name, query) in [
+        (
+            "create_table_as_valid",
+            "CREATE TABLE t2 AS SELECT t.a FROM t;",
+        ),
+        (
+            "create_materialized_view_as_valid",
+            "CREATE MATERIALIZED VIEW mv1 AS SELECT t.a FROM t;",
+        ),
+        (
+            "create_view_as_valid",
+            "CREATE VIEW v1 AS SELECT t.a FROM t;",
+        ),
+    ] {
+        TestSetup {
+            name,
+            query,
+            setup: None,
+            test_db: &test_db,
+            typed_identifiers: vec![],
+        }
+        .test()
+        .await;
+    }
+
+    for object_name in ["t2", "mv1", "v1"] {
+        let object = sqlx::query_scalar::<_, Option<String>>("SELECT to_regclass($1)::text")
+            .bind(object_name)
+            .fetch_one(&test_db)
+            .await
+            .expect("Failed to check created object");
+        assert_eq!(object, None, "{object_name} should not have been created");
+    }
+}
+
+#[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
 async fn invalid_type_in_function(test_db: PgPool) {
     // create or replace function clean_up(uid uuid)
     // returns void

--- a/crates/pgls_typecheck/tests/snapshots/create_materialized_view_as_invalid_column.snap
+++ b/crates/pgls_typecheck/tests/snapshots/create_materialized_view_as_invalid_column.snap
@@ -1,0 +1,8 @@
+---
+source: crates/pgls_typecheck/tests/diagnostics.rs
+assertion_line: 96
+expression: content
+---
+CREATE MATERIALIZED VIEW mv1 AS SELECT t.~~~nope~~~ FROM t;
+
+column t.nope does not exist

--- a/crates/pgls_typecheck/tests/snapshots/create_materialized_view_as_valid.snap
+++ b/crates/pgls_typecheck/tests/snapshots/create_materialized_view_as_valid.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pgls_typecheck/tests/diagnostics.rs
+assertion_line: 96
+expression: content
+---
+No Diagnostic

--- a/crates/pgls_typecheck/tests/snapshots/create_table_as_invalid_column.snap
+++ b/crates/pgls_typecheck/tests/snapshots/create_table_as_invalid_column.snap
@@ -1,0 +1,8 @@
+---
+source: crates/pgls_typecheck/tests/diagnostics.rs
+assertion_line: 96
+expression: content
+---
+CREATE TABLE t2 AS SELECT t.~~~nope~~~ FROM t;
+
+column t.nope does not exist

--- a/crates/pgls_typecheck/tests/snapshots/create_table_as_invalid_relation.snap
+++ b/crates/pgls_typecheck/tests/snapshots/create_table_as_invalid_relation.snap
@@ -1,0 +1,8 @@
+---
+source: crates/pgls_typecheck/tests/diagnostics.rs
+assertion_line: 96
+expression: content
+---
+CREATE TABLE t3 AS SELECT t.a FROM ~~~nonexistent_table~~~ AS t;
+
+relation &quot;nonexistent_table&quot; does not exist

--- a/crates/pgls_typecheck/tests/snapshots/create_table_as_valid.snap
+++ b/crates/pgls_typecheck/tests/snapshots/create_table_as_valid.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pgls_typecheck/tests/diagnostics.rs
+assertion_line: 96
+expression: content
+---
+No Diagnostic

--- a/crates/pgls_typecheck/tests/snapshots/create_view_as_invalid_column.snap
+++ b/crates/pgls_typecheck/tests/snapshots/create_view_as_invalid_column.snap
@@ -1,0 +1,8 @@
+---
+source: crates/pgls_typecheck/tests/diagnostics.rs
+assertion_line: 96
+expression: content
+---
+CREATE VIEW v1 AS SELECT t.~~~nope~~~ FROM t;
+
+column t.nope does not exist

--- a/crates/pgls_typecheck/tests/snapshots/create_view_as_valid.snap
+++ b/crates/pgls_typecheck/tests/snapshots/create_view_as_valid.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pgls_typecheck/tests/diagnostics.rs
+assertion_line: 96
+expression: content
+---
+No Diagnostic

--- a/crates/pgls_workspace/src/workspace/server.tests.rs
+++ b/crates/pgls_workspace/src/workspace/server.tests.rs
@@ -686,6 +686,77 @@ async fn test_disable_typecheck(test_db: PgPool) {
 }
 
 #[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
+async fn test_create_as_typecheck_diagnostic_offsets(test_db: PgPool) {
+    test_db
+        .execute("CREATE TABLE public.t (a INT);")
+        .await
+        .expect("setup sql failed");
+
+    let options = test_db.connect_options();
+    let mut conf = PartialConfiguration::init();
+    conf.merge_with(PartialConfiguration {
+        db: Some(PartialDatabaseConfiguration {
+            host: Some(options.get_host().to_string()),
+            port: Some(options.get_port()),
+            database: Some(options.get_database().unwrap().to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let workspace = get_test_workspace(Some(conf)).expect("Unable to create test workspace");
+    let path = PgLSPath::new("test.sql");
+    let content = "SELECT 1;\nCREATE VIEW v1 AS SELECT t.nope FROM t;";
+
+    workspace
+        .open_file(OpenFileParams {
+            path: path.clone(),
+            content: content.into(),
+            version: 1,
+        })
+        .expect("Unable to open test file");
+
+    let diagnostics = workspace
+        .pull_file_diagnostics(crate::workspace::PullFileDiagnosticsParams {
+            path,
+            categories: RuleCategories::all(),
+            max_diagnostics: 100,
+            only: vec![],
+            skip: vec![],
+        })
+        .expect("Unable to pull diagnostics")
+        .diagnostics;
+
+    let typecheck_diagnostics = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic
+                .category()
+                .is_some_and(|category| category.name() == "typecheck")
+                && serde_json::to_string(diagnostic)
+                    .is_ok_and(|serialized| serialized.contains("42703"))
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        typecheck_diagnostics.len(),
+        1,
+        "Expected one 42703 typecheck diagnostic, got {diagnostics:#?}"
+    );
+
+    let expected_start = content.find("nope").expect("missing test identifier");
+    let expected_span = TextRange::new(
+        u32::try_from(expected_start).unwrap().into(),
+        u32::try_from(expected_start + "nope".len()).unwrap().into(),
+    );
+
+    assert_eq!(
+        typecheck_diagnostics[0].location().span,
+        Some(expected_span)
+    );
+}
+
+#[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
 async fn test_named_params(_test_db: PgPool) {
     let conf = PartialConfiguration::init();
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

Typechecking skips the query body of `CREATE TABLE AS`, `CREATE MATERIALIZED VIEW AS`,
and `CREATE VIEW AS`.

As a result, database errors inside the embedded `SELECT` are not reported.

Fixes #786.

## What is the new behavior?

The typechecker now extracts and prepares the inner query of supported `CREATE … AS`
statements without executing the outer DDL.

PostgreSQL diagnostics are mapped back to their original positions in the enclosing
SQL document. Valid create-as statements produce no diagnostic and do not create the
target table or view.

## Additional context

Added regression coverage for:

- invalid columns and relations in `CREATE TABLE AS`;
- invalid columns in materialized views and views;
- valid create-as queries without DDL side effects;
- workspace-level file-relative diagnostic offsets.

Validated with:

```text
cargo test -p pgls_typecheck
cargo test -p pgls_workspace test_create_as_typecheck_diagnostic_offsets
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings