### PR TITLE
fix: handle named parameters in identifier contexts

### DIFF
--- a/crates/pgls_lexer/src/lib.rs
+++ b/crates/pgls_lexer/src/lib.rs
@@ -6,7 +6,10 @@ mod params;
 pub use crate::codegen::syntax_kind::SyntaxKind;
 pub use crate::lexed::{LexDiagnostic, Lexed};
 pub use crate::lexer::Lexer;
-pub use crate::params::convert_to_positional_params;
+pub use crate::params::{
+    NamedParameterConversion, convert_to_positional_params,
+    convert_to_positional_params_with_metadata,
+};
 
 /// Lex the input string into tokens and diagnostics
 pub fn lex(input: &str) -> Lexed<'_> {

--- a/crates/pgls_lexer/src/lib.rs
+++ b/crates/pgls_lexer/src/lib.rs
@@ -1,10 +1,12 @@
 mod codegen;
 mod lexed;
 mod lexer;
+mod params;
 
 pub use crate::codegen::syntax_kind::SyntaxKind;
 pub use crate::lexed::{LexDiagnostic, Lexed};
 pub use crate::lexer::Lexer;
+pub use crate::params::convert_to_positional_params;
 
 /// Lex the input string into tokens and diagnostics
 pub fn lex(input: &str) -> Lexed<'_> {

--- a/crates/pgls_lexer/src/params.rs
+++ b/crates/pgls_lexer/src/params.rs
@@ -23,18 +23,25 @@ const IDENTIFIER_CONTEXT: [SyntaxKind; 15] = [
     SyntaxKind::DOT,
 ];
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NamedParameterConversion {
+    pub sql: String,
+    pub has_identifier_parameters: bool,
+}
+
 /// Converts named parameters in a SQL query string to parser-compatible placeholders.
 ///
 /// Replacements preserve the source byte length so parser diagnostics can be mapped directly
 /// back to the original query. A raw colon inside brackets is left untouched because it may be
 /// PostgreSQL array-slice syntax rather than a named parameter.
-pub fn convert_to_positional_params(text: &str) -> String {
+pub fn convert_to_positional_params_with_metadata(text: &str) -> NamedParameterConversion {
     let mut result = String::with_capacity(text.len());
     let mut value_params: HashMap<&str, usize> = HashMap::new();
     let mut identifier_params: HashMap<&str, usize> = HashMap::new();
     let mut value_index = 1;
     let mut identifier_index = 0;
     let mut bracket_depth = 0_usize;
+    let mut has_identifier_parameters = false;
 
     let lexed = lex(text);
     for (token_idx, kind) in lexed.tokens().enumerate() {
@@ -58,6 +65,10 @@ pub fn convert_to_positional_params(text: &str) -> String {
                 _ if previous.is_some_and(|kind| IDENTIFIER_CONTEXT.contains(&kind)) => true,
                 _ => false,
             };
+
+            if is_identifier {
+                has_identifier_parameters = true;
+            }
 
             let replacement = if is_identifier {
                 let index = *identifier_params.entry(token_text).or_insert_with(|| {
@@ -88,7 +99,14 @@ pub fn convert_to_positional_params(text: &str) -> String {
     }
 
     debug_assert_eq!(result.len(), text.len());
-    result
+    NamedParameterConversion {
+        sql: result,
+        has_identifier_parameters,
+    }
+}
+
+pub fn convert_to_positional_params(text: &str) -> String {
+    convert_to_positional_params_with_metadata(text).sql
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -248,5 +266,35 @@ mod tests {
 
         assert_eq!(normalized, "select arr[$1      ], arr[$2    ], arr[$3    ]");
         assert_eq!(normalized.len(), input.len());
+    }
+
+    #[test]
+    fn reports_identifier_parameter_conversion_metadata() {
+        let input = "select * from :raw_data.documents where id = :id";
+        let conversion = convert_to_positional_params_with_metadata(input);
+
+        assert_eq!(
+            conversion.sql,
+            "select * from a        .documents where id = $1 "
+        );
+        assert!(conversion.has_identifier_parameters);
+        assert_eq!(conversion.sql.len(), input.len());
+        assert_eq!(convert_to_positional_params(input), conversion.sql);
+    }
+
+    #[test]
+    fn value_parameters_and_array_slices_do_not_report_identifier_metadata() {
+        let value_input = "select :id, @name, $email, :'status'";
+        let value_conversion = convert_to_positional_params_with_metadata(value_input);
+
+        assert!(!value_conversion.has_identifier_parameters);
+        assert_eq!(value_conversion.sql.len(), value_input.len());
+
+        let slice_input = "select arr[3:array_upper(arr, 1)]";
+        let slice_conversion = convert_to_positional_params_with_metadata(slice_input);
+
+        assert!(!slice_conversion.has_identifier_parameters);
+        assert_eq!(slice_conversion.sql, slice_input);
+        assert_eq!(slice_conversion.sql.len(), slice_input.len());
     }
 }

--- a/crates/pgls_lexer/src/params.rs
+++ b/crates/pgls_lexer/src/params.rs
@@ -1,0 +1,138 @@
+use std::collections::HashMap;
+
+use crate::{SyntaxKind, lex};
+
+// Keywords that, when preceding a named parameter, indicate that the parameter should be treated
+// as an identifier rather than a positional parameter.
+const IDENTIFIER_CONTEXT: [SyntaxKind; 15] = [
+    SyntaxKind::TO_KW,
+    SyntaxKind::FROM_KW,
+    SyntaxKind::SCHEMA_KW,
+    SyntaxKind::TABLE_KW,
+    SyntaxKind::INDEX_KW,
+    SyntaxKind::CONSTRAINT_KW,
+    SyntaxKind::OWNER_KW,
+    SyntaxKind::ROLE_KW,
+    SyntaxKind::USER_KW,
+    SyntaxKind::DATABASE_KW,
+    SyntaxKind::TYPE_KW,
+    SyntaxKind::CAST_KW,
+    SyntaxKind::ALTER_KW,
+    SyntaxKind::DROP_KW,
+    // for schema.table style identifiers
+    SyntaxKind::DOT,
+];
+
+/// Converts named parameters in a SQL query string to positional parameters.
+///
+/// This function scans the input SQL string for named parameters (e.g., `@param`, `:param`, `:'param'`)
+/// and replaces them with positional parameters (e.g., `$1`, `$2`, etc.).
+///
+/// It maintains the original spacing of the named parameters in the output string.
+///
+/// Useful for preparing SQL queries for parsing or execution where named paramters are not supported.
+pub fn convert_to_positional_params(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut param_mapping: HashMap<&str, usize> = HashMap::new();
+    let mut param_index = 1;
+
+    let lexed = lex(text);
+    for (token_idx, kind) in lexed.tokens().enumerate() {
+        if kind == SyntaxKind::EOF {
+            break;
+        }
+
+        let token_text = lexed.text(token_idx);
+
+        if matches!(kind, SyntaxKind::NAMED_PARAM) {
+            let idx = match param_mapping.get(token_text) {
+                Some(&index) => index,
+                None => {
+                    let index = param_index;
+                    param_mapping.insert(token_text, index);
+                    param_index += 1;
+                    index
+                }
+            };
+
+            // find previous non-trivia token
+            let prev_token = (0..token_idx)
+                .rev()
+                .map(|i| lexed.kind(i))
+                .find(|kind| !kind.is_trivia());
+
+            let replacement = match prev_token {
+                Some(k) if IDENTIFIER_CONTEXT.contains(&k) => deterministic_identifier(idx - 1),
+                _ => format!("${idx}"),
+            };
+            let original_len = token_text.len();
+            let replacement_len = replacement.len();
+
+            result.push_str(&replacement);
+
+            // maintain original spacing
+            if replacement_len < original_len {
+                result.push_str(&" ".repeat(original_len - replacement_len));
+            }
+        } else {
+            result.push_str(token_text);
+        }
+    }
+
+    result
+}
+
+const ALPHABET: [char; 26] = [
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+    't', 'u', 'v', 'w', 'x', 'y', 'z',
+];
+
+/// Generates a deterministic identifier based on the given index.
+fn deterministic_identifier(idx: usize) -> String {
+    let iteration = idx / ALPHABET.len();
+    let pos = idx % ALPHABET.len();
+
+    format!(
+        "{}{}",
+        ALPHABET[pos],
+        if iteration > 0 {
+            deterministic_identifier(iteration - 1)
+        } else {
+            "".to_string()
+        }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deterministic_identifier() {
+        assert_eq!(deterministic_identifier(0), "a");
+        assert_eq!(deterministic_identifier(25), "z");
+        assert_eq!(deterministic_identifier(26), "aa");
+        assert_eq!(deterministic_identifier(27), "ba");
+        assert_eq!(deterministic_identifier(51), "za");
+    }
+
+    #[test]
+    fn test_convert_to_positional_params() {
+        let input = "select * from users where id = @one and name = :two and email = :'three';";
+        let result = convert_to_positional_params(input);
+        assert_eq!(
+            result,
+            "select * from users where id = $1   and name = $2   and email = $3      ;"
+        );
+    }
+
+    #[test]
+    fn test_convert_to_positional_params_with_duplicates() {
+        let input = "select * from users where first_name = @one and starts_with(email, @one) and created_at > @two;";
+        let result = convert_to_positional_params(input);
+        assert_eq!(
+            result,
+            "select * from users where first_name = $1   and starts_with(email, $1  ) and created_at > $2  ;"
+        );
+    }
+}

--- a/crates/pgls_lexer/src/params.rs
+++ b/crates/pgls_lexer/src/params.rs
@@ -23,18 +23,18 @@ const IDENTIFIER_CONTEXT: [SyntaxKind; 15] = [
     SyntaxKind::DOT,
 ];
 
-/// Converts named parameters in a SQL query string to positional parameters.
+/// Converts named parameters in a SQL query string to parser-compatible placeholders.
 ///
-/// This function scans the input SQL string for named parameters (e.g., `@param`, `:param`, `:'param'`)
-/// and replaces them with positional parameters (e.g., `$1`, `$2`, etc.).
-///
-/// It maintains the original spacing of the named parameters in the output string.
-///
-/// Useful for preparing SQL queries for parsing or execution where named paramters are not supported.
+/// Replacements preserve the source byte length so parser diagnostics can be mapped directly
+/// back to the original query. A raw colon inside brackets is left untouched because it may be
+/// PostgreSQL array-slice syntax rather than a named parameter.
 pub fn convert_to_positional_params(text: &str) -> String {
     let mut result = String::with_capacity(text.len());
-    let mut param_mapping: HashMap<&str, usize> = HashMap::new();
-    let mut param_index = 1;
+    let mut value_params: HashMap<&str, usize> = HashMap::new();
+    let mut identifier_params: HashMap<&str, usize> = HashMap::new();
+    let mut value_index = 1;
+    let mut identifier_index = 0;
+    let mut bracket_depth = 0_usize;
 
     let lexed = lex(text);
     for (token_idx, kind) in lexed.tokens().enumerate() {
@@ -45,41 +45,103 @@ pub fn convert_to_positional_params(text: &str) -> String {
         let token_text = lexed.text(token_idx);
 
         if matches!(kind, SyntaxKind::NAMED_PARAM) {
-            let idx = match param_mapping.get(token_text) {
-                Some(&index) => index,
-                None => {
-                    let index = param_index;
-                    param_mapping.insert(token_text, index);
-                    param_index += 1;
-                    index
+            let flavor = NamedParamFlavor::from_text(token_text);
+            let previous = previous_non_trivia_kind(&lexed, token_idx);
+            let next = next_non_trivia_kind(&lexed, token_idx);
+            let is_identifier = match flavor {
+                Some(NamedParamFlavor::ColonRaw) if bracket_depth > 0 => {
+                    result.push_str(token_text);
+                    continue;
                 }
+                Some(NamedParamFlavor::ColonIdentifier) => true,
+                _ if next == Some(SyntaxKind::DOT) => true,
+                _ if previous.is_some_and(|kind| IDENTIFIER_CONTEXT.contains(&kind)) => true,
+                _ => false,
             };
 
-            // find previous non-trivia token
-            let prev_token = (0..token_idx)
-                .rev()
-                .map(|i| lexed.kind(i))
-                .find(|kind| !kind.is_trivia());
-
-            let replacement = match prev_token {
-                Some(k) if IDENTIFIER_CONTEXT.contains(&k) => deterministic_identifier(idx - 1),
-                _ => format!("${idx}"),
+            let replacement = if is_identifier {
+                let index = *identifier_params.entry(token_text).or_insert_with(|| {
+                    let index = identifier_index;
+                    identifier_index += 1;
+                    index
+                });
+                identifier_replacement(index, token_text.len())
+            } else {
+                let index = *value_params.entry(token_text).or_insert_with(|| {
+                    let index = value_index;
+                    value_index += 1;
+                    index
+                });
+                format!("${index}")
             };
-            let original_len = token_text.len();
-            let replacement_len = replacement.len();
 
-            result.push_str(&replacement);
-
-            // maintain original spacing
-            if replacement_len < original_len {
-                result.push_str(&" ".repeat(original_len - replacement_len));
-            }
+            push_padded_replacement(&mut result, &replacement, token_text.len());
         } else {
             result.push_str(token_text);
         }
+
+        match kind {
+            SyntaxKind::L_BRACK => bracket_depth += 1,
+            SyntaxKind::R_BRACK => bracket_depth = bracket_depth.saturating_sub(1),
+            _ => {}
+        }
     }
 
+    debug_assert_eq!(result.len(), text.len());
     result
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NamedParamFlavor {
+    AtPrefix,
+    DollarRaw,
+    ColonRaw,
+    ColonString,
+    ColonIdentifier,
+}
+
+impl NamedParamFlavor {
+    fn from_text(text: &str) -> Option<Self> {
+        match text.as_bytes().first()? {
+            b'@' => Some(Self::AtPrefix),
+            b'$' => Some(Self::DollarRaw),
+            b':' if text.starts_with(":'") => Some(Self::ColonString),
+            b':' if text.starts_with(":\"") => Some(Self::ColonIdentifier),
+            b':' => Some(Self::ColonRaw),
+            _ => None,
+        }
+    }
+}
+
+fn previous_non_trivia_kind(lexed: &crate::Lexed<'_>, token_idx: usize) -> Option<SyntaxKind> {
+    (0..token_idx)
+        .rev()
+        .map(|idx| lexed.kind(idx))
+        .find(|kind| !kind.is_trivia())
+}
+
+fn next_non_trivia_kind(lexed: &crate::Lexed<'_>, token_idx: usize) -> Option<SyntaxKind> {
+    (token_idx + 1..lexed.len())
+        .map(|idx| lexed.kind(idx))
+        .find(|kind| !kind.is_trivia() && *kind != SyntaxKind::EOF)
+}
+
+fn push_padded_replacement(result: &mut String, replacement: &str, original_len: usize) {
+    assert!(
+        replacement.len() <= original_len,
+        "named parameter replacement must preserve source length"
+    );
+    result.push_str(replacement);
+    result.push_str(&" ".repeat(original_len - replacement.len()));
+}
+
+fn identifier_replacement(index: usize, max_len: usize) -> String {
+    let identifier = deterministic_identifier(index);
+    if identifier.len() <= max_len {
+        identifier
+    } else {
+        "a".to_string()
+    }
 }
 
 const ALPHABET: [char; 26] = [
@@ -134,5 +196,57 @@ mod tests {
             result,
             "select * from users where first_name = $1   and starts_with(email, $1  ) and created_at > $2  ;"
         );
+    }
+
+    #[test]
+    fn classifies_named_parameter_contexts() {
+        let cases = [
+            (
+                "select * from :schema.items where id = :id",
+                "select * from a      .items where id = $1 ",
+            ),
+            (
+                "select * from @schema.items where id = $id",
+                "select * from a      .items where id = $1 ",
+            ),
+            (
+                "select * from $schema.items where id = @id",
+                "select * from a      .items where id = $1 ",
+            ),
+            (
+                "select * from :\"schema\".items",
+                "select * from a        .items",
+            ),
+            (
+                "cross join :raw_data.migration_infos",
+                "cross join a        .migration_infos",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            let normalized = convert_to_positional_params(input);
+            assert_eq!(normalized, expected);
+            assert_eq!(normalized.len(), input.len());
+        }
+    }
+
+    #[test]
+    fn preserves_array_slices_and_keeps_parameter_indexes_contiguous() {
+        let input = "select arr[3:array_upper(arr, 1)], :value from :schema.items where id = :id";
+        let normalized = convert_to_positional_params(input);
+
+        assert!(normalized.contains("arr[3:array_upper(arr, 1)]"));
+        assert!(normalized.contains("$1    "));
+        assert!(normalized.contains("$2 "));
+        assert_eq!(normalized.len(), input.len());
+    }
+
+    #[test]
+    fn preserves_quoted_and_at_parameters_in_brackets() {
+        let input = "select arr[:'value'], arr[@value], arr[$value]";
+        let normalized = convert_to_positional_params(input);
+
+        assert_eq!(normalized, "select arr[$1      ], arr[$2    ], arr[$3    ]");
+        assert_eq!(normalized.len(), input.len());
     }
 }

--- a/crates/pgls_workspace/src/workspace/server.rs
+++ b/crates/pgls_workspace/src/workspace/server.rs
@@ -17,7 +17,7 @@ use document::{ExecuteStatementMapper, TypecheckDiagnosticsMapper};
 #[cfg(feature = "db")]
 use futures::{StreamExt, TryStreamExt, stream};
 #[cfg(feature = "db")]
-use pg_query::convert_to_positional_params;
+use pg_query::convert_to_positional_params_with_metadata;
 use pgls_analyse::AnalysisFilter;
 use pgls_analyser::{Analyser, AnalyserConfig, AnalyserParams, LinterOptions};
 
@@ -610,49 +610,63 @@ impl Workspace for WorkspaceServer {
                                     if let Some(ast) = ast {
                                         // Type checking
                                         if typecheck_enabled {
-                                            let typecheck_result =
-                                                pgls_typecheck::check_sql(TypecheckParams {
-                                                    conn: &pool,
-                                                    sql: convert_to_positional_params(id.content())
-                                                        .as_str(),
-                                                    ast: &ast,
-                                                    tree: &cst,
-                                                    schema_cache: schema_cache.as_ref(),
-                                                    search_path_patterns,
-                                                    identifiers: fn_sig
-                                                        .map(|s| {
-                                                            s.args
-                                                                .iter()
-                                                                .map(|a| TypedIdentifier {
-                                                                    path: s.name.clone(),
-                                                                    name: a.name.clone(),
-                                                                    type_: IdentifierType {
-                                                                        schema: a.type_.schema.clone(),
-                                                                        name: a.type_.name.clone(),
-                                                                        is_array: a.type_.is_array,
-                                                                    },
-                                                                })
-                                                                .collect::<Vec<_>>()
-                                                        })
-                                                        .unwrap_or_default(),
-                                                })
-                                                .await;
+                                            let conversion =
+                                                convert_to_positional_params_with_metadata(
+                                                    id.content(),
+                                                );
 
-                                            match typecheck_result {
-                                                Ok(Some(diag)) => {
-                                                    let r = diag
-                                                        .location()
-                                                        .span
-                                                        .map(|span| span + range.start());
-                                                    diagnostics.push(
-                                                        diag.with_file_path(
-                                                            path.as_path().display().to_string(),
-                                                        )
-                                                        .with_file_span(r.unwrap_or(range)),
-                                                    );
+                                            if !conversion.has_identifier_parameters {
+                                                let typecheck_result =
+                                                    pgls_typecheck::check_sql(TypecheckParams {
+                                                        conn: &pool,
+                                                        sql: conversion.sql.as_str(),
+                                                        ast: &ast,
+                                                        tree: &cst,
+                                                        schema_cache: schema_cache.as_ref(),
+                                                        search_path_patterns,
+                                                        identifiers: fn_sig
+                                                            .map(|s| {
+                                                                s.args
+                                                                    .iter()
+                                                                    .map(|a| TypedIdentifier {
+                                                                        path: s.name.clone(),
+                                                                        name: a.name.clone(),
+                                                                        type_: IdentifierType {
+                                                                            schema: a
+                                                                                .type_
+                                                                                .schema
+                                                                                .clone(),
+                                                                            name: a
+                                                                                .type_
+                                                                                .name
+                                                                                .clone(),
+                                                                            is_array: a
+                                                                                .type_
+                                                                                .is_array,
+                                                                        },
+                                                                    })
+                                                                    .collect::<Vec<_>>()
+                                                            })
+                                                            .unwrap_or_default(),
+                                                    })
+                                                    .await;
+
+                                                match typecheck_result {
+                                                    Ok(Some(diag)) => {
+                                                        let r = diag
+                                                            .location()
+                                                            .span
+                                                            .map(|span| span + range.start());
+                                                        diagnostics.push(
+                                                            diag.with_file_path(
+                                                                path.as_path().display().to_string(),
+                                                            )
+                                                            .with_file_span(r.unwrap_or(range)),
+                                                        );
+                                                    }
+                                                    Ok(None) => {}
+                                                    Err(err) => return Err(err),
                                                 }
-                                                Ok(None) => {}
-                                                Err(err) => return Err(err),
                                             }
                                         }
 

--- a/crates/pgls_workspace/src/workspace/server.tests.rs
+++ b/crates/pgls_workspace/src/workspace/server.tests.rs
@@ -737,6 +737,86 @@ async fn test_disable_typecheck(test_db: PgPool) {
 }
 
 #[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
+async fn named_identifier_params_skip_only_affected_typecheck(test_db: PgPool) {
+    let connect_options = test_db.connect_options();
+    let host = connect_options.get_host().to_string();
+    let port = connect_options.get_port();
+    let database = connect_options
+        .get_database()
+        .expect("test database must have a name")
+        .to_string();
+
+    let mut conf = PartialConfiguration::init();
+    conf.merge_with(PartialConfiguration {
+        db: Some(PartialDatabaseConfiguration {
+            host: Some(host),
+            port: Some(port),
+            database: Some(database),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    test_db
+        .execute("CREATE TABLE named_parameter_typecheck_users (id integer PRIMARY KEY);")
+        .await
+        .expect("test table setup must succeed");
+
+    let workspace = get_test_workspace(Some(conf)).expect("Unable to create test workspace");
+    let path = PgLSPath::new("named-identifier-parameter.sql");
+    let content = r#"
+SELECT * FROM :raw_data.documents;
+SELECT missing_column FROM named_parameter_typecheck_users;
+"#;
+
+    workspace
+        .open_file(OpenFileParams {
+            path: path.clone(),
+            content: content.into(),
+            version: 1,
+        })
+        .expect("Unable to open test file");
+
+    let diagnostics = workspace
+        .pull_file_diagnostics(crate::workspace::PullFileDiagnosticsParams {
+            path,
+            categories: RuleCategories::all(),
+            max_diagnostics: 100,
+            only: vec![],
+            skip: vec![],
+        })
+        .expect("Unable to pull diagnostics")
+        .diagnostics;
+
+    let typecheck_diagnostics = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic
+                .category()
+                .is_some_and(|category| category.name() == "typecheck")
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        typecheck_diagnostics.len(),
+        1,
+        "only the second statement should produce a typecheck diagnostic: {diagnostics:#?}"
+    );
+
+    let missing_column_start = content
+        .find("missing_column")
+        .expect("test SQL contains the invalid column");
+    let missing_column_end = missing_column_start + "missing_column".len();
+    assert_eq!(
+        typecheck_diagnostics[0].location().span,
+        Some(TextRange::new(
+            u32::try_from(missing_column_start).unwrap().into(),
+            u32::try_from(missing_column_end).unwrap().into(),
+        ))
+    );
+}
+
+#[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
 async fn test_named_params(_test_db: PgPool) {
     let conf = PartialConfiguration::init();
 

--- a/crates/pgls_workspace/src/workspace/server.tests.rs
+++ b/crates/pgls_workspace/src/workspace/server.tests.rs
@@ -266,6 +266,57 @@ async fn test_syntax_error(test_db: PgPool) {
 }
 
 #[tokio::test]
+async fn named_parameter_normalization_preserves_syntax_diagnostic_offsets() {
+    let workspace = get_test_workspace(None).expect("Unable to create test workspace");
+    let path = PgLSPath::new("named-parameter.sql");
+    let content = "SELECT * FROM :very_long_schema.existing_table AS t seect 1;";
+
+    workspace
+        .open_file(OpenFileParams {
+            path: path.clone(),
+            content: content.into(),
+            version: 1,
+        })
+        .expect("Unable to open test file");
+
+    let diagnostics = workspace
+        .pull_file_diagnostics(crate::workspace::PullFileDiagnosticsParams {
+            path,
+            categories: RuleCategories::all(),
+            max_diagnostics: 100,
+            only: vec![],
+            skip: vec![],
+        })
+        .expect("Unable to pull diagnostics")
+        .diagnostics;
+
+    let syntax_diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| {
+            diagnostic
+                .category()
+                .is_some_and(|category| category.name() == "syntax")
+        })
+        .expect("Expected one syntax diagnostic");
+
+    let expected_span = TextRange::new(0.into(), u32::try_from(content.len()).unwrap().into());
+    assert_eq!(syntax_diagnostic.location().span, Some(expected_span));
+
+    let qualifier_start = content
+        .find(":very_long_schema")
+        .expect("query contains the named qualifier");
+    assert_ne!(
+        syntax_diagnostic.location().span,
+        Some(TextRange::new(
+            u32::try_from(qualifier_start).unwrap().into(),
+            u32::try_from(qualifier_start + ":very_long_schema".len())
+                .unwrap()
+                .into()
+        ))
+    );
+}
+
+#[tokio::test]
 async fn correctly_ignores_files() {
     let mut conf = PartialConfiguration::init();
     conf.merge_with(PartialConfiguration {

--- a/crates/pgls_workspace/src/workspace/server/pg_query.rs
+++ b/crates/pgls_workspace/src/workspace/server/pg_query.rs
@@ -126,6 +126,40 @@ mod tests {
     }
 
     #[test]
+    fn parses_named_schema_qualifiers() {
+        let cases = [
+            r#"
+SELECT
+    customers.id
+FROM staging.customers
+CROSS JOIN :raw_data.migration_infos;
+"#,
+            "SELECT * FROM @schema.items;",
+            "SELECT * FROM $schema.items;",
+            r#"SELECT * FROM :"schema".items;"#,
+            "SELECT * FROM :table;",
+        ];
+
+        let store = PgQueryStore::new();
+        for input in cases {
+            let result = store.get_or_cache_ast(&StatementId::new(input));
+            assert!(result.is_ok(), "failed to parse {input:?}: {result:?}");
+        }
+    }
+
+    #[test]
+    fn preserves_array_slice_syntax_when_normalizing_parameters() {
+        let input = "SELECT array_to_string(arr[3:array_upper(arr, 1)], ',') FROM t;";
+        let normalized = convert_to_positional_params(input);
+
+        assert_eq!(normalized, input);
+
+        let store = PgQueryStore::new();
+        let result = store.get_or_cache_ast(&StatementId::new(input));
+        assert!(result.is_ok(), "failed to parse {input:?}: {result:?}");
+    }
+
+    #[test]
     fn test_plpgsql_syntax_error() {
         let input = "
 create function test_organisation_id ()

--- a/crates/pgls_workspace/src/workspace/server/pg_query.rs
+++ b/crates/pgls_workspace/src/workspace/server/pg_query.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, LazyLock, Mutex};
 
 use lru::LruCache;
-pub use pgls_lexer::convert_to_positional_params;
+pub use pgls_lexer::{convert_to_positional_params, convert_to_positional_params_with_metadata};
 use pgls_query_ext::diagnostics::*;
 use pgls_text_size::TextRange;
 use regex::Regex;

--- a/crates/pgls_workspace/src/workspace/server/pg_query.rs
+++ b/crates/pgls_workspace/src/workspace/server/pg_query.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, LazyLock, Mutex};
 
 use lru::LruCache;
-use pgls_lexer::lex;
+pub use pgls_lexer::convert_to_positional_params;
 use pgls_query_ext::diagnostics::*;
 use pgls_text_size::TextRange;
 use regex::Regex;
@@ -104,139 +103,9 @@ fn is_composite_type_error(err: &str) -> bool {
     COMPOSITE_TYPE_ERROR_RE.is_match(err)
 }
 
-// Keywords that, when preceding a named parameter, indicate that the parameter should be treated
-// as an identifier rather than a positional parameter.
-const IDENTIFIER_CONTEXT: [pgls_lexer::SyntaxKind; 15] = [
-    pgls_lexer::SyntaxKind::TO_KW,
-    pgls_lexer::SyntaxKind::FROM_KW,
-    pgls_lexer::SyntaxKind::SCHEMA_KW,
-    pgls_lexer::SyntaxKind::TABLE_KW,
-    pgls_lexer::SyntaxKind::INDEX_KW,
-    pgls_lexer::SyntaxKind::CONSTRAINT_KW,
-    pgls_lexer::SyntaxKind::OWNER_KW,
-    pgls_lexer::SyntaxKind::ROLE_KW,
-    pgls_lexer::SyntaxKind::USER_KW,
-    pgls_lexer::SyntaxKind::DATABASE_KW,
-    pgls_lexer::SyntaxKind::TYPE_KW,
-    pgls_lexer::SyntaxKind::CAST_KW,
-    pgls_lexer::SyntaxKind::ALTER_KW,
-    pgls_lexer::SyntaxKind::DROP_KW,
-    // for schema.table style identifiers
-    pgls_lexer::SyntaxKind::DOT,
-];
-
-/// Converts named parameters in a SQL query string to positional parameters.
-///
-/// This function scans the input SQL string for named parameters (e.g., `@param`, `:param`, `:'param'`)
-/// and replaces them with positional parameters (e.g., `$1`, `$2`, etc.).
-///
-/// It maintains the original spacing of the named parameters in the output string.
-///
-/// Useful for preparing SQL queries for parsing or execution where named paramters are not supported.
-pub fn convert_to_positional_params(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut param_mapping: HashMap<&str, usize> = HashMap::new();
-    let mut param_index = 1;
-
-    let lexed = lex(text);
-    for (token_idx, kind) in lexed.tokens().enumerate() {
-        if kind == pgls_lexer::SyntaxKind::EOF {
-            break;
-        }
-
-        let token_text = lexed.text(token_idx);
-
-        if matches!(kind, pgls_lexer::SyntaxKind::NAMED_PARAM) {
-            let idx = match param_mapping.get(token_text) {
-                Some(&index) => index,
-                None => {
-                    let index = param_index;
-                    param_mapping.insert(token_text, index);
-                    param_index += 1;
-                    index
-                }
-            };
-
-            // find previous non-trivia token
-            let prev_token = (0..token_idx)
-                .rev()
-                .map(|i| lexed.kind(i))
-                .find(|kind| !kind.is_trivia());
-
-            let replacement = match prev_token {
-                Some(k) if IDENTIFIER_CONTEXT.contains(&k) => deterministic_identifier(idx - 1),
-                _ => format!("${idx}"),
-            };
-            let original_len = token_text.len();
-            let replacement_len = replacement.len();
-
-            result.push_str(&replacement);
-
-            // maintain original spacing
-            if replacement_len < original_len {
-                result.push_str(&" ".repeat(original_len - replacement_len));
-            }
-        } else {
-            result.push_str(token_text);
-        }
-    }
-
-    result
-}
-
-const ALPHABET: [char; 26] = [
-    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
-    't', 'u', 'v', 'w', 'x', 'y', 'z',
-];
-
-/// Generates a deterministic identifier based on the given index.
-fn deterministic_identifier(idx: usize) -> String {
-    let iteration = idx / ALPHABET.len();
-    let pos = idx % ALPHABET.len();
-
-    format!(
-        "{}{}",
-        ALPHABET[pos],
-        if iteration > 0 {
-            deterministic_identifier(iteration - 1)
-        } else {
-            "".to_string()
-        }
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_deterministic_identifier() {
-        assert_eq!(deterministic_identifier(0), "a");
-        assert_eq!(deterministic_identifier(25), "z");
-        assert_eq!(deterministic_identifier(26), "aa");
-        assert_eq!(deterministic_identifier(27), "ba");
-        assert_eq!(deterministic_identifier(51), "za");
-    }
-
-    #[test]
-    fn test_convert_to_positional_params() {
-        let input = "select * from users where id = @one and name = :two and email = :'three';";
-        let result = convert_to_positional_params(input);
-        assert_eq!(
-            result,
-            "select * from users where id = $1   and name = $2   and email = $3      ;"
-        );
-    }
-
-    #[test]
-    fn test_convert_to_positional_params_with_duplicates() {
-        let input = "select * from users where first_name = @one and starts_with(email, @one) and created_at > @two;";
-        let result = convert_to_positional_params(input);
-        assert_eq!(
-            result,
-            "select * from users where first_name = $1   and starts_with(email, $1  ) and created_at > $2  ;"
-        );
-    }
 
     #[test]
     fn test_positional_params_in_grant() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Named parameters are normalized before parsing, but parameters used as SQL
identifiers need a synthetic identifier placeholder because PostgreSQL does not
accept positional parameters in relation or qualifier positions.

For example, `:raw_data.documents` is normalized to a parser-compatible form
such as `a.documents`. Parsing succeeds, but typechecking then reports the
false positive `relation "a.documents" does not exist`.

Fixes #787.

## What is the new behavior?

Named parameters are classified by SQL context:

- value parameters continue to become positional parameters;
- identifier parameters, including qualified names such as
  `:raw_data.documents`, become length-preserving synthetic identifiers for
  parsing;
- PostgreSQL typechecking is skipped only for the statement containing an
  unresolved named identifier parameter.

Parsing, syntax diagnostics, linting, and `plpgsql_check` remain enabled.
Other statements in the same file continue to be typechecked normally.

## Additional context

The conversion keeps the original byte length so parser diagnostic offsets stay
aligned with the source document.

The change does not attempt to resolve external aliases such as `raw_data`.
A future dbsh integration may provide that semantic context.