### PR TITLE
fix(diagnostics): prevent panics in indented multiline frames

### DIFF
--- a/crates/pgls_cli/tests/assert_check.rs
+++ b/crates/pgls_cli/tests/assert_check.rs
@@ -120,6 +120,30 @@ fn check_stdin_snapshot() {
     target_os = "windows",
     ignore = "snapshot expectations only validated on unix-like platforms"
 )]
+fn check_indented_cte_after_blank_line_does_not_panic() {
+    let output = run_check_with(
+        &[
+            "--config-path",
+            CONFIG_PATH,
+            "--stdin-file-path",
+            "repro.sql",
+            "--log-level",
+            "none",
+        ],
+        Some("WITH\n\n x AS (SELECT 1 AS a)\nSELECT x.a FROM x;\n"),
+        None,
+    );
+
+    assert!(!output.contains("Encountered an unexpected error"));
+    assert!(!output.contains("assertion failed"));
+    assert_snapshot!(output);
+}
+
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "snapshot expectations only validated on unix-like platforms"
+)]
 fn check_directory_traversal_snapshot() {
     let project_dir = Path::new("tests/fixtures/traversal");
     assert_snapshot!(run_check_with(

--- a/crates/pgls_cli/tests/snapshots/assert_check__check_indented_cte_after_blank_line_does_not_panic.snap
+++ b/crates/pgls_cli/tests/snapshots/assert_check__check_indented_cte_after_blank_line_does_not_panic.snap
@@ -1,0 +1,12 @@
+---
+source: crates/pgls_cli/tests/assert_check.rs
+assertion_line: 139
+expression: output
+---
+status: success
+stdout:
+WITH
+
+ x AS (SELECT 1 AS a)
+SELECT x.a FROM x;
+stderr:

--- a/crates/pgls_diagnostics/src/display.rs
+++ b/crates/pgls_diagnostics/src/display.rs
@@ -988,6 +988,22 @@ mod tests {
     }
 
     #[test]
+    fn renders_multiline_spans_ending_before_indentation() {
+        let diag = TestDiagnostic::<LogAdvices> {
+            path: Some("repro.sql".into()),
+            span: Some(TextRange::new(TextSize::from(4), TextSize::from(6))),
+            source_code: Some("WITH\n\n x AS (SELECT 1 AS a)\nSELECT x.a FROM x;".into()),
+            ..TestDiagnostic::empty()
+        };
+
+        let verbose = markup!({ PrintDiagnostic::verbose(&diag) }).to_owned();
+        let search = markup!({ PrintDiagnostic::search(&diag) }).to_owned();
+
+        assert!(!verbose.is_empty());
+        assert!(!search.is_empty());
+    }
+
+    #[test]
     fn test_diff_advice() {
         let diag = TestDiagnostic {
             advice: Some(DiffAdvice),

--- a/crates/pgls_diagnostics/src/display/frame.rs
+++ b/crates/pgls_diagnostics/src/display/frame.rs
@@ -204,7 +204,8 @@ pub(super) fn print_frame(fmt: &mut fmt::Formatter<'_>, location: Location<'_>) 
                     .checked_sub(line_text.trim_start().text_len())
                     // SAFETY: The length of `line_text.trim_start()` should
                     // never be larger than `line_text` itself
-                    .expect("integer overflow");
+                    .expect("integer overflow")
+                    .min(end_index_relative_to_line);
                 Some(TextRange::new(start_index, end_index_relative_to_line))
             } else {
                 None
@@ -295,8 +296,9 @@ pub(super) fn print_highlighted_frame(
         } else if is_last_line {
             let start_index: u32 = current_text.text_len().into();
 
-            let safe_start_index =
-                start_index.saturating_sub(current_text.trim_start().text_len().into());
+            let safe_start_index = start_index
+                .saturating_sub(current_text.trim_start().text_len().into())
+                .min(end_index_relative_to_line.into());
 
             TextRange::new(TextSize::from(safe_start_index), end_index_relative_to_line)
         } else {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Rendering a multiline syntax diagnostic can panic when its span ends at column zero
of an indented line.

This happens with a `WITH` statement followed by a blank line and an indented CTE.

Fixes #785.

## What is the new behavior?

Both diagnostic frame renderers clamp the last-line marker start to the span end
before constructing the range.

The CLI now reports the syntax diagnostic normally instead of panicking.

## Additional context

Regression coverage includes:

- generic diagnostic frame rendering
- the original CLI reproduction with an indented CTE after a blank line

Validation:

- `cargo test -p pgls_diagnostics`
- `cargo test -p pgls_cli check_indented_cte_after_blank_line_does_not_panic`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`