### PR TITLE
fix(splitter): keep CTE queries attached to inserts

### DIFF
--- a/crates/pgls_statement_splitter/src/lib.rs
+++ b/crates/pgls_statement_splitter/src/lib.rs
@@ -353,6 +353,23 @@ END;",
     }
 
     #[test]
+    fn insert_with_cte() {
+        let insert = "INSERT INTO target (id)
+WITH source AS (
+    SELECT 1 AS id
+)
+SELECT id FROM source;";
+        let input = format!(
+            "{insert}
+SELECT 2;"
+        );
+
+        Tester::from(input.as_str())
+            .expect_statements(vec![insert, "SELECT 2;"])
+            .assert_no_errors();
+    }
+
+    #[test]
     fn c_style_comments() {
         Tester::from("/* this is a test */\nselect 1").expect_statements(vec!["select 1"]);
     }

--- a/crates/pgls_statement_splitter/src/splitter/dml.rs
+++ b/crates/pgls_statement_splitter/src/splitter/dml.rs
@@ -82,7 +82,7 @@ pub(crate) fn insert(p: &mut Splitter) -> SplitterResult {
     p.expect(SyntaxKind::INSERT_KW)?;
     p.expect(SyntaxKind::INTO_KW)?;
 
-    unknown(p, &[SyntaxKind::SELECT_KW])
+    unknown(p, &[SyntaxKind::WITH_KW, SyntaxKind::SELECT_KW])
 }
 
 pub(crate) fn update(p: &mut Splitter) -> SplitterResult {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

A valid `INSERT INTO … WITH … SELECT` statement is split after the target column
list because the statement splitter treats `WITH` as the start of a new
statement.

PostgreSQL then receives the incomplete `INSERT INTO … (...)` fragment and
reports `syntax error at end of input`.

## What is the new behavior?

`WITH` is now handled like `SELECT` while splitting an `INSERT`, so a
CTE-backed insert remains a single statement until its terminating semicolon.

A regression test also verifies that a subsequent semicolon-terminated
statement is still split separately.

## Additional context

Validated with:

```text
cargo test -p pgls_statement_splitter
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
```