### PR TITLE
fix(splitter): keep create-as CTEs attached

### DIFF
--- a/crates/pgls_statement_splitter/src/lib.rs
+++ b/crates/pgls_statement_splitter/src/lib.rs
@@ -353,6 +353,54 @@ END;",
     }
 
     #[test]
+    fn create_as_with_cte() {
+        let create_statements = [
+            "CREATE TABLE target AS",
+            "CREATE MATERIALIZED VIEW target AS",
+            "CREATE VIEW target AS",
+        ];
+
+        for create_as in create_statements {
+            let create = format!(
+                "{create_as}
+WITH cte AS (
+    SELECT 1 AS id
+)
+SELECT id FROM cte;"
+            );
+            let input = format!(
+                "{create}
+SELECT 2;"
+            );
+
+            Tester::from(input.as_str())
+                .expect_statements(vec![create.as_str(), "SELECT 2;"])
+                .assert_no_errors();
+        }
+    }
+
+    #[test]
+    fn create_view_with_options_as_cte() {
+        Tester::from(
+            "CREATE VIEW target WITH (security_invoker) AS
+WITH cte AS (
+    SELECT 1 AS id
+)
+SELECT id FROM cte;
+SELECT 2;",
+        )
+        .expect_statements(vec![
+            "CREATE VIEW target WITH (security_invoker) AS
+WITH cte AS (
+    SELECT 1 AS id
+)
+SELECT id FROM cte;",
+            "SELECT 2;",
+        ])
+        .assert_no_errors();
+    }
+
+    #[test]
     fn c_style_comments() {
         Tester::from("/* this is a test */\nselect 1").expect_statements(vec!["select 1"]);
     }
@@ -450,6 +498,25 @@ LIMIT
     fn with_cte() {
         Tester::from("with test as (select 1 as id) select * from test;")
             .expect_statements(vec!["with test as (select 1 as id) select * from test;"]);
+    }
+
+    #[test]
+    fn with_cte_followed_by_statement() {
+        Tester::from(
+            "WITH cte AS (
+    SELECT 1 AS id
+)
+SELECT id FROM cte;
+SELECT 2;",
+        )
+        .expect_statements(vec![
+            "WITH cte AS (
+    SELECT 1 AS id
+)
+SELECT id FROM cte;",
+            "SELECT 2;",
+        ])
+        .assert_no_errors();
     }
 
     #[test]

--- a/crates/pgls_statement_splitter/src/splitter/ddl.rs
+++ b/crates/pgls_statement_splitter/src/splitter/ddl.rs
@@ -2,12 +2,31 @@ use pgls_lexer::SyntaxKind;
 
 use crate::splitter::common::SplitterResult;
 
-use super::{Splitter, common::unknown};
+use super::{
+    Splitter,
+    common::{parenthesis, unknown},
+    dml::cte,
+};
 
 pub(crate) fn create(p: &mut Splitter) -> SplitterResult {
     p.expect(SyntaxKind::CREATE_KW)?;
 
-    unknown(p, &[SyntaxKind::WITH_KW])
+    loop {
+        unknown(p, &[])?;
+
+        if p.current() != SyntaxKind::WITH_KW {
+            return Ok(());
+        }
+
+        if p.look_back(true) == Some(SyntaxKind::AS_KW) {
+            return cte(p);
+        }
+
+        p.expect(SyntaxKind::WITH_KW)?;
+        if p.current() == SyntaxKind::L_PAREN {
+            parenthesis(p)?;
+        }
+    }
 }
 
 pub(crate) fn alter(p: &mut Splitter) -> SplitterResult {

--- a/crates/pgls_statement_splitter/src/splitter/dml.rs
+++ b/crates/pgls_statement_splitter/src/splitter/dml.rs
@@ -27,17 +27,13 @@ pub(crate) fn cte(p: &mut Splitter) -> SplitterResult {
         }
     }
 
-    unknown(
-        p,
-        &[
-            SyntaxKind::SELECT_KW,
-            SyntaxKind::INSERT_KW,
-            SyntaxKind::UPDATE_KW,
-            SyntaxKind::DELETE_KW,
-            SyntaxKind::MERGE_KW,
-        ],
-    )?;
-    Ok(())
+    match p.current() {
+        SyntaxKind::SELECT_KW => select(p),
+        SyntaxKind::INSERT_KW => insert(p),
+        SyntaxKind::UPDATE_KW => update(p),
+        SyntaxKind::DELETE_KW => delete(p),
+        _ => unknown(p, &[]),
+    }
 }
 
 /// `EXPLAIN [ ANALYZE ] [ VERBOSE ] <statement>` and


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`CREATE TABLE AS`, `CREATE MATERIALIZED VIEW AS`, and `CREATE VIEW AS`
statements whose query starts with a CTE are split before the final query.

This leaves PostgreSQL with an incomplete `CREATE ... AS WITH ...` fragment and
produces a `syntax error at end of input` diagnostic.

## What is the new behavior?

The statement splitter now keeps a CTE attached to its enclosing `CREATE ... AS`
statement.

It also preserves `WITH (...)` DDL options and correctly ends the CTE statement
at its semicolon, without absorbing the following SQL statement.

## Additional context

Added regression coverage for:

- `CREATE TABLE AS WITH ...`;
- `CREATE MATERIALIZED VIEW AS WITH ...`;
- `CREATE VIEW AS WITH ...`;
- `CREATE VIEW WITH (...) AS WITH ...`;
- a CTE followed by another statement.

Validated with:

```text
cargo test -p pgls_statement_splitter
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
```